### PR TITLE
Load plugins from npm using the bosco-command- prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ To create your own Bosco commands for your project (ones that you don't want to 
 
 At TES we have a github project that is a 'default' Bosco workspace that contains local commands and configuration that teams use as their workspace.
 
+## Npm Commands
+
+You can create bosco commands as npm packages and install it via npm (local or global). These commands must be named bosco-command-*command* such as bosco-command-ports. Bosco will try to find such commands as long as they match the naming pattern. This was inspired by [Yeoman generators](http://yeoman.io/authoring/)
+
 ### Options and Args in new commands
 
 There are two ways of passing input through to a command: options and args.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "multimeter": "^0.1.1",
     "nconf": "^0.7.1",
     "node-sass": "^0.9.3",
+    "nplugm": "^1.0.1",
     "nsp": "^0.4.2",
     "parse-link-header": "^0.2.0",
     "pm2": "^0.12.1",


### PR DESCRIPTION
- This change allows us to npm install commands on workspaces instead of using them as local commands which improves command reusability. We can also stop adding deps to bosco's package.json that are only used by commands