### PR TITLE
bosco run now has --cdn command

### DIFF
--- a/commands/stop.js
+++ b/commands/stop.js
@@ -72,7 +72,13 @@ function cmd(bosco, args, next) {
             cb();
 
         }, function() {
-            scb();
+            // Special case for bosco-cdn, room for improvement to make this
+            // generic for all custom bosco services.
+            if (_.contains(runningServices, 'bosco-cdn')) {
+                return NodeRunner.stop({name: 'bosco-cdn'}, scb);
+            } else {
+                scb();
+            }
         });
 
     }

--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -79,12 +79,22 @@ Runner.prototype.start = function(options, next) {
 		executeCommand = true;
 	}
 
-	if(!self.bosco.exists(options.cwd + '/' + start)) {
-		self.bosco.warn('Can\'t start ' + options.name.red + ', as I can\'t find script: ' + start.red);
+  // If the command has a -- in it then we know it is passing parameters
+  // to pm2
+  var argumentPos = start.indexOf(' -- ');
+  var location = start;
+  var scriptArgs = [];
+  if (argumentPos > -1) {
+    scriptArgs = start.substring(argumentPos + 4, start.length).split(' ');
+    location = start.substring(0, argumentPos);
+  }
+
+	if(!self.bosco.exists(options.cwd + '/' + location)) {
+		self.bosco.warn('Can\'t start ' + options.name.red + ', as I can\'t find script: ' + location.red);
 		return next();
 	}
     self.bosco.log('Starting ' + options.name + ' ...');
-	pm2.start(start, { name: options.name, cwd: options.cwd, watch: options.watch, executeCommand: executeCommand, force: true }, next);
+	pm2.start(location, { name: options.name, cwd: options.cwd, watch: options.watch, executeCommand: executeCommand, force: true, scriptArgs: scriptArgs }, next);
 }
 
 /**


### PR DESCRIPTION
This will run `bosco cdn` as a command supervised by pm2, which allows it to be
stop and started as well being able to view its logs via `pm2`.

Its not an elegant solution by a long shot, however it works.

Example:

```sh
$ bosco run --cdn
$ bosco stop #This will stop cdn aswell
```