### PR TITLE
Adding external depencency support

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -112,6 +112,14 @@ function cmd(bosco, args, cb) {
             });
         }
 
+        var addExternals = function(external) {
+            var externalConfig = _.isObject(external) ? external : _.find(bosco.config.stores.file.store.externals, function(externalConfig) {
+                return externalConfig.name === external
+            })
+            if (!externalConfig) return next(new Error('Trying to run ' + external + ' which does not exist in ~/.bosco/bosco.json' + '. This is a dependency for ' + revDepTree[currentRepo]));
+            runList.push(externalConfig)
+        }
+
         // First build the tree and filtered core list
         repos.forEach(function(repo) {
             svcConfig = getRunConfig(repo);
@@ -132,6 +140,8 @@ function cmd(bosco, args, cb) {
                 if (svcConfig.service.dependsOn) {
                     addDependencies(currentRepo, svcConfig.service.dependsOn);
                 }
+
+                _.each(svcConfig.service.externals, addExternals)
             }
         }
 


### PR DESCRIPTION
You can depend on external docker files, or TES own ones without adding them to your team. Either add an externals list to the project's bosco-service.json

```json
{
    "tags": ["jobs"],
    "service": {
        "name": "http2amqp",
        "externals": [{
            "name":"infra-rabbitmq",
            "service": {
                "type":"docker",
                "name":"infra-rabbitmq",
                "registry":"docker-registry.tescloud.com",
                "username": "tescloud",
                "version": "latest",
                "alwaysPull": true,
                "docker":{
                    "HostConfig": {
                        "PortBindings": {
                            "5672/tcp": [{
                                "HostIp": "0.0.0.0",
                                "HostPort": "5672"
                             }],
                            "15672/tcp":  [{
                                "HostIp": "0.0.0.0",
                                "HostPort": "15672"
                            }]
                        }
                    }
                }
            }
        }]
    }
}
```
or define the external in ~/.bosco.json and reference it in the project's bosco-service.json
```json
{
    "tags": ["jobs"],
    "service": {
        "name": "http2amqp",
        "externals": ["infra-rabbitmq"]
    }
}
```