### PR TITLE
git pull for branch not always master fixes #73

### DIFF
--- a/commands/pull.js
+++ b/commands/pull.js
@@ -97,7 +97,7 @@ function pull(bosco, progressbar, bar, repoPath, next) {
         return next();
     }
 
-    exec('git pull --rebase origin master', {
+    exec('git pull --rebase', {
       cwd: repoPath
     }, function(err, stdout, stderr) {
         if(progressbar) bar.tick();


### PR DESCRIPTION
git clone will automatically set the remote origin, so this should function as normal