### PR TITLE
Refactor the start function to account for the babel-node transpiler

### DIFF
--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -49,52 +49,73 @@ Runner.prototype.listNotRunning = function(detailed, next) {
  */
 Runner.prototype.start = function(options, next) {
 
-	var self = this;
-	// Remove node from the start script as not req'd for PM2
-	var startCmd = options.service.start, startArr, start, ext;
+  var self = this;
+  // Remove node from the start script as not req'd for PM2
+  var startCmd = options.service.start;
+  var startArr = startCmd.split(' ');
+  var start;
+  var ext;
+  var interpreter;
+  var scriptArgs;
 
-	if(startCmd.split(' ')[0] == 'node') {
-		startArr = startCmd.split(' ');
-		startArr.shift();
-		start = startArr.join(' ');
+  if(startArr[0] == 'node' || startArr[0] == 'babel-node') {
+    if (startArr[0] == 'babel-node') {
+      interpreter = 'babel-node';
+    }
+    startArr.shift();
+    start = startArr.join(' ');
 
-		ext = path.extname(startCmd);
+    ext = path.extname(startCmd);
 
-		if(!path.extname(start)) {
-			ext = '.js';
-			start = start + '.js';
-		}
-	} else {
-		start = startCmd;
-	}
+    if(!path.extname(start)) {
+      ext = '.js';
+      start = start + '.js';
+    }
+  } else {
+    start = startCmd;
+  }
 
-	var executeCommand = false;
-
-	if (ext != '.js') {
-		executeCommand = true;
-	}
-
-	// Node 0.10.x has a problem with cluster mode
-	if (process.version.match(/0.10/)) {
-		executeCommand = true;
-	}
+  var location = start;
 
   // If the command has a -- in it then we know it is passing parameters
   // to pm2
   var argumentPos = start.indexOf(' -- ');
-  var location = start;
-  var scriptArgs = [];
   if (argumentPos > -1) {
     scriptArgs = start.substring(argumentPos + 4, start.length).split(' ');
     location = start.substring(0, argumentPos);
   }
 
-	if(!self.bosco.exists(options.cwd + '/' + location)) {
-		self.bosco.warn('Can\'t start ' + options.name.red + ', as I can\'t find script: ' + location.red);
-		return next();
-	}
-    self.bosco.log('Starting ' + options.name.cyan + ' ...');
-	pm2.start(location, { name: options.name, cwd: options.cwd, watch: options.watch, executeCommand: executeCommand, force: true, scriptArgs: scriptArgs }, next);
+  if(!self.bosco.exists(options.cwd + '/' + location)) {
+    self.bosco.warn('Can\'t start ' + options.name.red + ', as I can\'t find script: ' + location.red);
+    return next();
+  }
+
+  self.bosco.log('Starting ' + options.name.cyan + ' ...');
+
+  var pm2Options = {
+    name: options.name,
+    cwd: options.cwd,
+    force: true
+  };
+
+  // Node 0.10.x has a problem with cluster mode
+  if (process.version.match(/0.10/) || ext != '.js') {
+    pm2Options.executeCommand = true;
+  }
+
+  if (options.watch) {
+    pm2Options.watch = options.watch;
+  }
+
+  if (scriptArgs && scriptArgs.length) {
+    pm2Options.scriptArgs = scriptArgs;
+  }
+
+  if (interpreter) {
+    pm2Options.interpreter = interpreter;
+  }
+
+  pm2.start(location, pm2Options, next);
 }
 
 /**


### PR DESCRIPTION
[Babel](https://babeljs.io/) is a Javascript transpiler introduced to our project by @bettiolo. It comes with a neat ```node```-wrapping function, ```babel-node```, that runs your code through the transpiler without needing to include that fact in your code anywhere.

To run this code with ```bosco start```, which runs the node process through PM2, I need to pass it the ```--interpreter=babel-node``` flag, which is what this refactor aims to do.