### PR TITLE
allow for earlier versions of node

### DIFF
--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -122,21 +122,25 @@ Runner.prototype.stop = function(options, next) {
 
 function getInterpreter(bosco, service) {
 
-  if(!service.nodeVersion) {
-    return;
+  var version = semver.parse(service.nodeVersion);
+
+  if (!version) {
+    return '';
   }
 
-  var homeFolder = bosco.findHomeFolder(), nvmNodePath;
+  var homeFolder = bosco.findHomeFolder();
+  var nvmBase = '.nvm';
+  var runtime = 'node';
 
-  if(semver.gte(service.nodeVersion, '1.0.0')) {
-    nvmNodePath = path.join('/.nvm/versions/io.js/','v' + service.nodeVersion,'/bin/node');
-  } else if(semver.gte(service.nodeVersion, '0.12.0')) {
-    nvmNodePath = path.join('/.nvm/versions/node/','v' + service.nodeVersion,'/bin/node');
-  } else {
-    nvmNodePath = path.join('/.nvm/','v' + service.nodeVersion,'/bin/node');
+  if (version.major >= 1) {
+    runtime = 'io.js';
   }
 
-  return path.join(homeFolder, nvmNodePath);
+  if (runtime === 'io.js' || version.minor >= 12) { 
+    nvmBase = path.join(nvmBase, 'versions', runtime);
+  }
+
+  return path.join(homeFolder, nvmBase, 'v' + version, 'bin', 'node');
 
 }
 

--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -128,10 +128,12 @@ function getInterpreter(bosco, service) {
 
   var homeFolder = bosco.findHomeFolder(), nvmNodePath;
 
-  if(semver.gt(service.nodeVersion, '0.12.0')) {
+  if(semver.gte(service.nodeVersion, '1.0.0')) {
     nvmNodePath = path.join('/.nvm/versions/io.js/','v' + service.nodeVersion,'/bin/node');
-  } else {
+  } else if(semver.gte(service.nodeVersion, '0.12.0')) {
     nvmNodePath = path.join('/.nvm/versions/node/','v' + service.nodeVersion,'/bin/node');
+  } else {
+    nvmNodePath = path.join('/.nvm/','v' + service.nodeVersion,'/bin/node');
   }
 
   return path.join(homeFolder, nvmNodePath);

--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -130,13 +130,9 @@ function getInterpreter(bosco, service) {
 
   var homeFolder = bosco.findHomeFolder();
   var nvmBase = '.nvm';
-  var runtime = 'node';
+  var runtime = (version.major >= 1) ? 'io.js' : 'node';
 
-  if (version.major >= 1) {
-    runtime = 'io.js';
-  }
-
-  if (runtime === 'io.js' || version.minor >= 12) { 
+  if (runtime === 'io.js' || version.minor >= 12) {
     nvmBase = path.join(nvmBase, 'versions', runtime);
   }
 


### PR DESCRIPTION
If the engine is set in package.json to a version of node earlier than v0.12, bosco should still be able to parse this and find the correct interpreter.