### PR TITLE
Renaming bosco clean to bosco clean-modules

### DIFF
--- a/commands/clean-modules.js
+++ b/commands/clean-modules.js
@@ -4,9 +4,9 @@ var green = '\u001b[42m \u001b[0m';
 var red = '\u001b[41m \u001b[0m';
 
 module.exports = {
-    name:'clean',
+    name:'clean-modules',
     description:'Cleans out node_modules and re-runs npm install against all repos',
-    example:'bosco clean -r <repoPattern>',
+    example:'bosco clean-modules -r <repoPattern>',
     cmd:cmd
 }
 


### PR DESCRIPTION
The reason for this change is `bosco-clean` has been broken since the
introduction of `bosco clone --clean` due to how arguments are handled
this removes `bosco clean`.

A better fix would be to fix the root cause, however `bosco
clean-modules` makes more sense from the cli.