### PR TITLE
s3push fix

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,11 @@
 {
-  "node": true,
   "asi": true,
   "curly": false,
+  "eqnull": true,
   "latedef": false,
+  "node": true,
   "quotmark": true,
+  "trailing": true,
   "undef": true,
-  "unused": true,
-  "trailing": true
+  "unused": true
 }

--- a/commands/s3push.js
+++ b/commands/s3push.js
@@ -14,7 +14,7 @@ module.exports = {
 
 var tag = '', noprompt = false;
 
-function cmd(bosco, args) {
+function cmd(bosco, args, callback) {
 
     if(args.length > 0) tag = args[0];
 
@@ -28,7 +28,10 @@ function cmd(bosco, args) {
     bosco.log('Compile front end assets across services ' + (tag ? 'for tag: ' + tag.blue : ''));
 
     var repos = bosco.getRepos();
-    if(!repos) return bosco.error('You are repo-less :( You need to initialise bosco first, try \'bosco clone\'.');
+    if(!repos) {
+      bosco.error('You are repo-less :( You need to initialise bosco first, try \'bosco clone\'.');
+      callback(new Error('no repos'));
+    }
 
     var pushAllToS3 = function(staticAssets, next) {
 
@@ -76,24 +79,36 @@ function cmd(bosco, args) {
     }
 
     var pushToS3 = function(file, next) {
-        if(!bosco.knox) return bosco.warn('Knox AWS not configured for environment ' + bosco.options.envrionment + ' - so not pushing ' + file.path + ' to S3.');
+        if(!bosco.knox) {
+          bosco.warn('Knox AWS not configured for environment ' + bosco.options.envrionment + ' - so not pushing ' + file.path + ' to S3.');
+          next(null, {file: file});
+        }
+
         gzip(file.content, function(err, buffer) {
+            if (err) return next(err);
+
             var headers = {
               'Content-Type':file.mimeType,
               'Content-Encoding':'gzip',
               'Cache-Control': ('max-age=' + (maxAge === 0 ? '0, must-revalidate' : maxAge))
             };
             bosco.knox.putBuffer(buffer, file.path, headers, function(err, res) {
-              if(res.statusCode != 200 && !err) err = {message:'S3 error, code ' + res.statusCode};
-              bosco.log('Pushed to S3: ' + cdnUrl + file.path);
-              if(compoxureUrl && file.type == 'html') {
-                primeCompoxure(cdnUrl + file.path, file.content.toString(), function(err) {
-                    if(err) bosco.error('Error flushing compoxure: ' + err.message);
-                    next(err, {file: file});
-                });
-              } else {
-                next(err, {file: file});
+              if (!err && res.statusCode >= 300) {
+                  err = new Error('S3 error, code ' + res.statusCode);
+                  err.statusCode = res.statusCode;
               }
+
+              if (err) return next(err);
+
+              bosco.log('Pushed to S3: ' + cdnUrl + file.path);
+              if (!compoxureUrl || file.type != 'html') {
+                  return next(null, {file: file});
+              }
+
+              primeCompoxure(cdnUrl + file.path, file.content.toString(), function(err) {
+                  if (err) bosco.error('Error flushing compoxure');
+                  next(err, {file: file});
+              });
             });
         });
     }
@@ -138,12 +153,12 @@ function cmd(bosco, args) {
           });
         });
 
-        req.on('error', function(e) {
+        req.on('error', function(err) {
           // TODO: handle error.
-          bosco.error('There was an error posting fragment to Compoxure: ' + e.message);
+          bosco.error('There was an error posting fragment to Compoxure');
           if(!calledNext) {
             calledNext = true;
-            return next();
+            return next(err);
           }
         });
 
@@ -171,7 +186,7 @@ function cmd(bosco, args) {
          });
     }
 
-    var go = function() {
+    var go = function(next) {
 
         bosco.log('Compiling front end assets, this can take a while ... ');
 
@@ -185,21 +200,30 @@ function cmd(bosco, args) {
         }
 
         bosco.staticUtils.getStaticAssets(options, function(err, staticAssets) {
+            if (err) {
+                bosco.error('There was an error: ' + err.message);
+                return next(err);
+            }
+
             pushAllToS3(staticAssets, function(err) {
-                if(err) return bosco.error('There was an error: ' + err.message);
+                if (err) {
+                    bosco.error('There was an error: ' + err.message);
+                    return next(err);
+                }
                 bosco.log('Done');
+                next();
             });
         });
     }
 
-    if(!noprompt) {
-        var confirmMsg = 'Are you sure you want to publish '.white + (tag ? 'all ' + tag.blue + ' assets in ' : 'ALL'.red + ' assets in ').white + bosco.options.environment.blue + ' (y/N)?'.white
-        confirm(confirmMsg, function(err, confirmed) {
-            if(!err && confirmed) go();
-        })
-    } else {
-        go();
-    }
+    if (noprompt) return go(callback);
+
+    var confirmMsg = 'Are you sure you want to publish '.white + (tag ? 'all ' + tag.blue + ' assets in ' : 'ALL'.red + ' assets in ').white + bosco.options.environment.blue + ' (y/N)?'.white
+    confirm(confirmMsg, function(err, confirmed) {
+        if (err) return callback(err);
+        if (!confirmed) return callback(new Error('Not confirmed'));
+        go(callback);
+    })
 
     function getS3Content(file) {
         return file.data || new Buffer(file.content);

--- a/commands/s3push.js
+++ b/commands/s3push.js
@@ -29,8 +29,8 @@ function cmd(bosco, args, callback) {
 
     var repos = bosco.getRepos();
     if(!repos) {
-      bosco.error('You are repo-less :( You need to initialise bosco first, try \'bosco clone\'.');
-      callback(new Error('no repos'));
+        bosco.error('You are repo-less :( You need to initialise bosco first, try \'bosco clone\'.');
+        return callback(new Error('no repos'));
     }
 
     var pushAllToS3 = function(staticAssets, next) {
@@ -80,8 +80,8 @@ function cmd(bosco, args, callback) {
 
     var pushToS3 = function(file, next) {
         if(!bosco.knox) {
-          bosco.warn('Knox AWS not configured for environment ' + bosco.options.envrionment + ' - so not pushing ' + file.path + ' to S3.');
-          next(null, {file: file});
+            bosco.warn('Knox AWS not configured for environment ' + bosco.options.envrionment + ' - so not pushing ' + file.path + ' to S3.');
+            return next(null, {file: file});
         }
 
         gzip(file.content, function(err, buffer) {

--- a/index.js
+++ b/index.js
@@ -219,15 +219,24 @@ Bosco.prototype._cmd = function() {
         command = args.shift(),
         commandModule = [self.getGlobalCommandFolder(), command, '.js'].join(''),
         localCommandModule = [self.getLocalCommandFolder(), command, '.js'].join(''),
+        commandPath,
         module;
 
-    if (self.exists(commandModule)) {
-        module = require(commandModule);
+    if (self.exists(localCommandModule)) {
+        commandPath = localCommandModule;
     }
 
-    if (!module && self.exists(localCommandModule)) {
-        module = require(localCommandModule);
+    if (self.exists(commandModule)) {
+        if (module) {
+            self.warn('global command', commandModule, 'overriding local command', localCommandModule);
+        }
+        commandPath = commandModule;
     }
+
+    if (commandPath) {
+        module = require(commandPath);
+    }
+
     if (module) {
         return module.cmd(self, args, function(err) {
             var code = 0;

--- a/index.js
+++ b/index.js
@@ -541,7 +541,7 @@ Bosco.prototype._log = function(identifier, msg, args) {
     console.log(sf('[{time:hh:mm:ss}] {identifier}: {message}', parts));
 }
 
-Bosco.console = global.console;
+Bosco.prototype.console = global.console;
 
 Bosco.prototype.exists = function(path) {
     return fs.existsSync(path);

--- a/index.js
+++ b/index.js
@@ -217,24 +217,24 @@ Bosco.prototype._cmd = function() {
     var self = this,
         args = self.options.args,
         command = args.shift(),
-        commandModule = [self.getGlobalCommandFolder(), command, '.js'].join(''),
+        globalCommandModule = [self.getGlobalCommandFolder(), command, '.js'].join(''),
         localCommandModule = [self.getLocalCommandFolder(), command, '.js'].join(''),
-        commandPath,
+        commandModule,
         module;
 
     if (self.exists(localCommandModule)) {
-        commandPath = localCommandModule;
+        commandModule = localCommandModule;
     }
 
-    if (self.exists(commandModule)) {
-        if (module) {
-            self.warn('global command', commandModule, 'overriding local command', localCommandModule);
+    if (self.exists(globalCommandModule)) {
+        if (commandModule) {
+            self.warn('global command ' + globalCommandModule + ' overriding local command ' + localCommandModule);
         }
-        commandPath = commandModule;
+        commandModule = globalCommandModule;
     }
 
-    if (commandPath) {
-        module = require(commandPath);
+    if (commandModule) {
+        module = require(commandModule);
     }
 
     if (module) {

--- a/index.js
+++ b/index.js
@@ -524,6 +524,8 @@ Bosco.prototype._log = function(identifier, msg, args) {
     console.log(sf('[{time:hh:mm:ss}] {identifier}: {message}', parts));
 }
 
+Bosco.console = global.console;
+
 Bosco.prototype.exists = function(path) {
     return fs.existsSync(path);
 }

--- a/test/ExternalBuild.test.js
+++ b/test/ExternalBuild.test.js
@@ -67,7 +67,9 @@ describe('ExternalBuild', function() {
             expect(err).to.be.an(Error);
             expect(err).to.have.property('code', 1);
             expect(localBosco.console._log).to.eql(['hi']);
-            expect(localBosco._error).to.eql(['bye']);
+            expect(localBosco._error).to.have.length(2);
+            expect(localBosco._error[0]).to.contain('with code 1');
+            expect(localBosco._error[1]).to.be('bye');
             done();
         });
     });
@@ -166,8 +168,8 @@ describe('ExternalBuild', function() {
             expect(err).to.have.property('code', 0);
             expect(localBosco._error).to.be.an('array');
             expect(localBosco._error).to.have.length(2);
-            expect(localBosco._error[0]).to.contain('died with code 0');
-            expect(localBosco._error[1]).to.equal('\n');
+            expect(localBosco._error[0]).to.contain('with code 0');
+            expect(localBosco._error[1]).to.be('\n');
             done();
         });
     });
@@ -194,7 +196,7 @@ describe('ExternalBuild', function() {
             expect(err).to.be.an(Error);
             expect(err).to.not.have.property('code');
             expect(localBosco._error).to.be.an('array');
-            expect(localBosco._error).to.have.length(1);
+            expect(localBosco._error.length).to.be.greaterThan(0);
             expect(localBosco._error[0]).to.contain('timed out');
             done();
         });

--- a/test/ExternalBuild.test.js
+++ b/test/ExternalBuild.test.js
@@ -109,7 +109,7 @@ describe('ExternalBuild', function() {
         };
 
         doBuild(service, options, function(err) {
-            if (err) done(err);
+            if (err) return done(err);
             expect(localBosco).to.not.have.property('_log');
             expect(localBosco).to.not.have.property('_error');
             expect(localBosco.console).to.not.have.property('_log');
@@ -223,7 +223,7 @@ describe('ExternalBuild', function() {
         };
 
         doBuild(service, options, function(err) {
-            if (err) done(err);
+            if (err) return done(err);
             expect(localBosco.console._log).to.eql(['watchbye']);
             expect(localBosco).to.have.property('_log');
             expect(localBosco).to.not.have.property('_error');

--- a/test/StaticUtils.test.js
+++ b/test/StaticUtils.test.js
@@ -1,47 +1,12 @@
 'use strict';
 
-var expect = require("expect.js");
-var async = require('async');
-var fs = require('fs');
 var _ = require('lodash');
+var async = require('async');
+var expect = require('expect.js');
+var fs = require('fs');
+
+var boscoMock = require('./boscoMock');
 var StaticUtils = require('../src/StaticUtils');
-
-var repos = ["project1","project2"];
-
-
-var boscoMock = function() {
-
-  return {
-      log: function(msg) { this._log = this._log || []; this._log.push(msg) },
-      error: function(msg) { this._error = this._error || []; this._error.push(msg) },
-      warn: function(msg) { this._warn = this._warn || []; this._warn.push(msg) },
-      options: {
-          environment:'test'
-      },
-      getRepoPath: function(repo) {
-          return __dirname + "/TestOrganisation/" + repo
-      },
-      getAssetCdnUrl: function (asset) {
-          return 'http://my-awesome-cdn.example.com/' + asset;
-      },
-      exists: function(file) {
-          return fs.existsSync(file);
-      },
-      concurrency: {
-        cpu: 4,
-        network: 10
-      },
-      config: {
-          get: function(key) {
-              if(key == 'css:clean') {
-                return {enabled: true};
-              }
-              return key;
-          }
-      }
-  }
-
-}
 
 var arrayContains = function(arr, contains) {
   contains.forEach(function(contain) {
@@ -49,8 +14,7 @@ var arrayContains = function(arr, contains) {
   });
 }
 
-
-describe("Bosco Static Asset Handling", function() {
+describe('Bosco Static Asset Handling', function() {
 
     this.timeout(10000);
     this.slow(5000);
@@ -58,8 +22,8 @@ describe("Bosco Static Asset Handling", function() {
     it('should load static assets in un-minified cdn mode', function(done) {
 
         var options = {
-            repos: ["project1","project2"],
-            repoTag: "testy",
+            repos: ['project1','project2'],
+            repoTag: 'testy',
             minify: false,
             buildNumber: 'local',
             tagFilter: null,
@@ -71,10 +35,7 @@ describe("Bosco Static Asset Handling", function() {
         var utils = StaticUtils(localBosco);
 
         utils.getStaticAssets(options, function(err, assets) {
-
-            if (err) {
-                return done(err);
-            }
+            if (err) return done(err);
 
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
@@ -94,7 +55,7 @@ describe("Bosco Static Asset Handling", function() {
     it('should load static assets in un-minified cdn mode, deduping where necessary', function(done) {
 
         var options = {
-            repos: ["project1","project2"],
+            repos: ['project1','project2'],
             minify: false,
             buildNumber: 'local',
             tagFilter: null,
@@ -106,6 +67,7 @@ describe("Bosco Static Asset Handling", function() {
         var utils = StaticUtils(localBosco);
 
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
 
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
@@ -129,10 +91,10 @@ describe("Bosco Static Asset Handling", function() {
 
     });
 
-     it('should load static assets in minified cdn mode, deduping where necessary', function(done) {
+    it('should load static assets in minified cdn mode, deduping where necessary', function(done) {
 
         var options = {
-            repos: ["project1","project2"],
+            repos: ['project1','project2'],
             buildNumber: 'local',
             minify: true,
             tagFilter: null,
@@ -142,6 +104,7 @@ describe("Bosco Static Asset Handling", function() {
         var localBosco = boscoMock()
         var utils = StaticUtils(localBosco);
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
 
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
@@ -175,7 +138,7 @@ describe("Bosco Static Asset Handling", function() {
     it('should load static assets via globs', function(done) {
 
         var options = {
-            repos: ["project4"],
+            repos: ['project4'],
             minify: false,
             buildNumber: 'local',
             tagFilter: null,
@@ -187,6 +150,7 @@ describe("Bosco Static Asset Handling", function() {
         var utils = StaticUtils(localBosco);
 
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
 
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
@@ -202,10 +166,10 @@ describe("Bosco Static Asset Handling", function() {
 
     });
 
-   it('should load static assets in minified cdn mode, filtering by tag if specified', function(done) {
+    it('should load static assets in minified cdn mode, filtering by tag if specified', function(done) {
 
         var options = {
-            repos: ["project1","project2"],
+            repos: ['project1','project2'],
             minify: true,
             tagFilter: 'top',
             buildNumber: 'local',
@@ -216,6 +180,7 @@ describe("Bosco Static Asset Handling", function() {
         var utils = StaticUtils(boscoMock());
 
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
 
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
@@ -235,10 +200,10 @@ describe("Bosco Static Asset Handling", function() {
 
     });
 
-  it('should create a source map when minifying javascript', function(done) {
+    it('should create a source map when minifying javascript', function(done) {
 
         var options = {
-            repos: ["project1","project2"],
+            repos: ['project1','project2'],
             minify: true,
             tagFilter: 'top',
             buildNumber: 'local',
@@ -249,6 +214,8 @@ describe("Bosco Static Asset Handling", function() {
         var utils = StaticUtils(boscoMock());
 
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
+
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
               'project1/local/js/top.js.map',
@@ -260,10 +227,10 @@ describe("Bosco Static Asset Handling", function() {
 
     });
 
-   it('should create a formatted repo list when requested for cdn mode', function(done) {
+    it('should create a formatted repo list when requested for cdn mode', function(done) {
 
         var options = {
-            repos: ["project1","project2","project3"],
+            repos: ['project1','project2','project3'],
             minify: true,
             tagFilter: null,
             buildNumber: 'local',
@@ -274,6 +241,8 @@ describe("Bosco Static Asset Handling", function() {
         var utils = StaticUtils(boscoMock());
 
         utils.getStaticRepos(options, function(err, assets) {
+            if (err) return done(err);
+
             var assetKeys = _.keys(assets);
             expect(assetKeys).to.contain('formattedRepos');
             done();
@@ -283,15 +252,15 @@ describe("Bosco Static Asset Handling", function() {
 
 });
 
-describe("Bosco Static Asset Handling - Custom Building", function() {
+describe('Bosco Static Asset Handling - Custom Building', function() {
 
-  this.timeout(5000);
-  this.slow(5000);
+    this.timeout(5000);
+    this.slow(5000);
 
-  it('should execute bespoke build commands and use output', function(done) {
+    it('should execute bespoke build commands and use output', function(done) {
 
         var options = {
-            repos: ["project3"],
+            repos: ['project3'],
             minify: true,
             tagFilter: null,
             buildNumber: 'local',
@@ -302,6 +271,8 @@ describe("Bosco Static Asset Handling - Custom Building", function() {
         var utils = StaticUtils(boscoMock());
 
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
+
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
               'project3/local/html/compiled.js.html',
@@ -317,10 +288,29 @@ describe("Bosco Static Asset Handling - Custom Building", function() {
 
     });
 
-  it('should execute bespoke build commands and use output, and execute the watch command in watch mode', function(done) {
+    it('should fail if the build fails', function(done) {
+        var options = {
+            repos: ['projectFail'],
+            minify: true,
+            tagFilter: null,
+            buildNumber: 'local',
+            watchBuilds: false,
+            reloadOnly: false
+        }
+
+        var utils = StaticUtils(boscoMock());
+
+        utils.getStaticAssets(options, function(err, assets) {
+            expect(err).to.be.an(Error);
+            expect(err).to.have.property('code', 1);
+            done();
+        });
+    });
+
+    it('should execute bespoke watch commands in watch mode', function(done) {
 
         var options = {
-            repos: ["project3"],
+            repos: ['project3'],
             minify: true,
             tagFilter: null,
             buildNumber: 'local',
@@ -331,6 +321,8 @@ describe("Bosco Static Asset Handling - Custom Building", function() {
         var utils = StaticUtils(boscoMock());
 
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
+
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
               'project3/local/html/compiled.js.html',
@@ -345,12 +337,31 @@ describe("Bosco Static Asset Handling - Custom Building", function() {
 
     });
 
-it('should execute bespoke build commands and use output, and execute the watch command in watch mode and not minified', function(done) {
+    it('should fail if the watch command fails', function(done) {
+        var options = {
+            repos: ['projectFail'],
+            minify: true,
+            tagFilter: null,
+            buildNumber: 'local',
+            watchBuilds: true,
+            reloadOnly: false
+        }
+
+        var utils = StaticUtils(boscoMock());
+
+        utils.getStaticAssets(options, function(err, assets) {
+            expect(err).to.be.an(Error);
+            expect(err).to.have.property('code', 1);
+            done();
+        });
+    });
+
+    it('should execute bespoke watch commands in watch mode and not minified', function(done) {
 
         this.timeout(5000);
 
         var options = {
-            repos: ["project3"],
+            repos: ['project3'],
             minify: false,
             tagFilter: null,
             buildNumber: 'local',
@@ -361,6 +372,8 @@ it('should execute bespoke build commands and use output, and execute the watch 
         var utils = StaticUtils(boscoMock());
 
         utils.getStaticAssets(options, function(err, assets) {
+            if (err) return done(err);
+
             var assetKeys = _.pluck(assets,'assetKey');
             arrayContains(assetKeys, [
               'project3/local/html/compiled.js.html',

--- a/test/TestOrganisation/projectFail/bosco-service.json
+++ b/test/TestOrganisation/projectFail/bosco-service.json
@@ -4,11 +4,9 @@
         "name":"project3"
     },
     "build":{
-        "command":"echo 'This is the pseudo output of a build command.'",
-        "watch":{
-            "command":["bash", "-c", "echo \"COMPLETA\"; sleep 1"],
-            "ready":"COMPLETA",
-            "checkDelay":10
+        "command":"false",
+        "watch": {
+            "checkDelay": 10
         }
     },
     "assets": {

--- a/test/boscoMock.js
+++ b/test/boscoMock.js
@@ -1,0 +1,45 @@
+'use strict';
+var fs = require('fs');
+var _ = require('lodash');
+
+function getLogger() {
+    return {
+        log: function(msg) { this._log = this._log || []; this._log.push(msg) },
+        error: function(msg) { this._error = this._error || []; this._error.push(msg) },
+        warn: function(msg) { this._warn = this._warn || []; this._warn.push(msg) }
+    };
+}
+
+module.exports = function boscoMock(extra) {
+  return _.assign({}, getLogger(), {
+      console: getLogger(),
+      repos: [],
+      options: {
+          environment:'test'
+      },
+      getRepos: function() {
+          return this.repos;
+      },
+      getRepoPath: function(repo) {
+          return __dirname + "/TestOrganisation/" + repo
+      },
+      getAssetCdnUrl: function (asset) {
+          return 'http://my-awesome-cdn.example.com/' + asset;
+      },
+      exists: function(file) {
+          return fs.existsSync(file);
+      },
+      concurrency: {
+        cpu: 4,
+        network: 10
+      },
+      config: {
+          get: function(key) {
+              if(key == 'css:clean') {
+                return {enabled: true};
+              }
+              return key;
+          }
+      }
+  }, extra);
+}

--- a/test/s3push.test.js
+++ b/test/s3push.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+var _ = require('lodash');
+var expect = require('expect.js');
+var fs = require('fs');
+var zlib = require('zlib');
+
+var boscoMock = require('./boscoMock');
+var s3push = require('../commands/s3push');
+var StaticUtils = require('../src/StaticUtils');
+
+describe('s3push', function() {
+    this.timeout(2000);
+    this.slow(500);
+
+    it('should fail if the build fails', function(done) {
+        var options = {
+            repos: ['projectFail'],
+            noprompt: true
+        };
+        options.options = options;
+        var localBosco = boscoMock(options);
+        localBosco.staticUtils = StaticUtils(localBosco);
+
+        s3push.cmd(localBosco, [], function(err) {
+            expect(err).to.be.an(Error);
+            expect(err).to.have.property('code', 1);
+            done();
+        });
+    });
+
+    it('should fail when pushing to s3 errors', function(done) {
+        var message = 'This is a test error message';
+        function putBuffer(buffer, path, headers, next) {
+          next(new Error(message));
+        }
+        var options = {
+            repos: ['project3'],
+            noprompt: true,
+            knox: {putBuffer: putBuffer}
+        };
+        options.options = options;
+        var localBosco = boscoMock(options);
+        localBosco.staticUtils = StaticUtils(localBosco);
+
+        s3push.cmd(localBosco, [], function(err) {
+            expect(err).to.be.an(Error);
+            expect(err).to.have.property('message', message);
+            done();
+        });
+    });
+
+    it('should fail when pushing to s3 returns 300+ code', function(done) {
+        var message = 'This is a test error message';
+        var statusCode = 300;
+        function putBuffer(buffer, path, headers, next) {
+            next(null, {statusCode: statusCode});
+        }
+        var options = {
+            repos: ['project3'],
+            noprompt: true,
+            knox: {putBuffer: putBuffer}
+        };
+        options.options = options;
+        var localBosco = boscoMock(options);
+        localBosco.staticUtils = StaticUtils(localBosco);
+
+        s3push.cmd(localBosco, [], function(err) {
+            expect(err).to.be.an(Error);
+            expect(err).to.have.property('statusCode', 300);
+
+            statusCode = 400;
+            s3push.cmd(localBosco, [], function(err) {
+                expect(err).to.be.an(Error);
+                expect(err).to.have.property('statusCode', 400);
+
+                statusCode = 500;
+                s3push.cmd(localBosco, [], function(err) {
+                    expect(err).to.be.an(Error);
+                    expect(err).to.have.property('statusCode', 500);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should push all files to s3', function(done) {
+        var message = 'This is a test error message';
+        var s3Data = [];
+        function putBuffer(buffer, path, headers, next) {
+          zlib.gunzip(buffer, function(err, buf) {
+              if (err) return next(err);
+
+              s3Data.push({path: path, content: buf.toString()});
+              next(null, {statusCode: 200});
+          });
+        }
+        var options = {
+            repos: ['project3'],
+            noprompt: true,
+            environment: 'test',
+            knox: {putBuffer: putBuffer}
+        };
+        options.options = options;
+        var localBosco = boscoMock(options);
+        var staticData = [];
+        localBosco.staticUtils = StaticUtils(localBosco);
+        localBosco.staticUtils.oldGetStaticAssets = localBosco.staticUtils.getStaticAssets;
+        localBosco.staticUtils.getStaticAssets = function(options, next) {
+            return localBosco.staticUtils.oldGetStaticAssets(options, function(err, staticAssets) {
+                staticData = _.map(staticAssets, function(val) {
+                    return {path: 'test/' + val.assetKey, content: val.content};
+                });
+                staticData.push({path: 'test/index.html', content: staticAssets.formattedAssets});
+                next(err, staticAssets);
+            });
+        };
+
+        var repoPath = localBosco.getRepoPath('project3');
+        s3push.cmd(localBosco, [], function(err) {
+            if (err) return done(err);
+            expect(s3Data).to.eql(staticData);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Improve error handling in `ExternalBuild`, `StaticUtils`, and `s3push`.  Add comprehensive tests for `ExternalBuild`, and some tests for `s3push` and `StaticUtils`.  Should fix #98.