### PR TITLE
Enabling custom git hostnames in repositories

### DIFF
--- a/commands/template.js
+++ b/commands/template.js
@@ -56,8 +56,9 @@ function newServiceFromTemplate(bosco, args, next) {
     bosco.log('Creating new service: ' + targetServiceName.green + ' from template: ' + template.green);
 
     var gitCmd = 'git';
-    var host   = bosco.config.get('github:host') || 'github.com';
-    host       = "git@" + host + ":";
+    var host     = bosco.config.get('github:hostname') || 'github.com';
+    var hostUser = bosco.config.get('github:hostUser') || 'git';
+    host         = hostUser + "@" + host + ":";
 
     var gitOptions = ['clone','--depth=1', host + template, targetServiceName];
 

--- a/commands/template.js
+++ b/commands/template.js
@@ -59,7 +59,7 @@ function newServiceFromTemplate(bosco, args, next) {
     var host   = bosco.config.get('github:host') || 'github.com';
     host       = "git@" + host + ":";
 
-    var gitOptions = ['clone','--depth=1','git@github.com:' + template, targetServiceName];
+    var gitOptions = ['clone','--depth=1', host + template, targetServiceName];
 
     var serviceDirectory = path.resolve('.', targetServiceName);
 

--- a/commands/template.js
+++ b/commands/template.js
@@ -56,6 +56,9 @@ function newServiceFromTemplate(bosco, args, next) {
     bosco.log('Creating new service: ' + targetServiceName.green + ' from template: ' + template.green);
 
     var gitCmd = 'git';
+    var host   = bosco.config.get('github:host') || 'github.com';
+    host       = "git@" + host + ":";
+
     var gitOptions = ['clone','--depth=1','git@github.com:' + template, targetServiceName];
 
     var serviceDirectory = path.resolve('.', targetServiceName);

--- a/index.js
+++ b/index.js
@@ -446,10 +446,13 @@ Bosco.prototype.getLocalCommandFolder = function() {
 
 Bosco.prototype.getRepoUrl = function(repo) {
     var org;
+    var host = this.config.get('github:host') || 'github.com';
+    host     = "git@" + host + ":";
+
     if (repo.indexOf('/') < 0) {
         org = this.getOrg() + '/';
     }
-    return ['git@github.com:', org ? org : '', repo, '.git'].join('');
+    return [host, org ? org : '', repo, '.git'].join('');
 }
 
 Bosco.prototype.isLocalCdn = function () {

--- a/index.js
+++ b/index.js
@@ -446,8 +446,9 @@ Bosco.prototype.getLocalCommandFolder = function() {
 
 Bosco.prototype.getRepoUrl = function(repo) {
     var org;
-    var host = this.config.get('github:host') || 'github.com';
-    host     = "git@" + host + ":";
+    var host     = this.config.get('github:hostname') || 'github.com';
+    var hostUser = this.config.get('github:hostUser') || 'git';
+    host         = hostUser + "@" + host + ":";
 
     if (repo.indexOf('/') < 0) {
         org = this.getOrg() + '/';


### PR DESCRIPTION
Currently the clone script assumes that the repositories are all in the hostname `github.com`. However, if you have multiple Github accounts configured [1] you might have the hostname other than that.

The pull request adds the posibility to configure a different hostname using `bosco config set github.host` which will be used afterwards for the cloning process.



1. [Managing Multiple Git Accounts](http://mherman.org/blog/2013/09/16/managing-multiple-github-accounts/)