### PR TITLE
Allow ignoring errors for StaticUtils builds.

### DIFF
--- a/commands/cdn.js
+++ b/commands/cdn.js
@@ -173,6 +173,7 @@ function cmd(bosco, args) {
     tagFilter: null,
     watchBuilds: true,
     reloadOnly: false,
+    ignoreFailure: true,
     watchRegex: watchRegex,
     repoRegex: repoRegex,
     repoTag: repoTag,


### PR DESCRIPTION
* Output number of sucessful and failed builds
* Output the error message for each failed build

This fixes issues I've had where `bosco cdn` keels over when a build fails, even though I don't really care about it.

@dbellizzi 