### PR TITLE
Replace shadow-exception plugin with allow option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,9 @@
 {
   "extends": "airbnb/legacy",
-  "plugins": ["shadow-exception"],
   "rules": {
     "vars-on-top": 0,
     "id-length": 0,
     "func-names": 0,
-    "no-shadow": 0,
-    "shadow-exception/no-shadow": 2
+    "no-shadow": [2, {"allow": ["next", "err"]}]
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,9 +76,8 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.1",
-    "eslint": "^1.6.0",
+    "eslint": "^1.10.2",
     "eslint-config-airbnb": "^0.1.0",
-    "eslint-plugin-shadow-exception": "^1.1.2",
     "expect.js": "^0.3.1",
     "gulp": "^3.8.7",
     "gulp-marked-man": "^0.3.1",


### PR DESCRIPTION
shadow-exception deprecates itself on new version of eslint 

This resolves #117

With warm regards from [electrician](https://github.com/tes/electrician/blob/7e4d2f3d07713f6be2821dd31226d9fdd0703946/.eslintrc#L7)...