### PR TITLE
cannot find nsp module error in bosco v0.5.1

### DIFF
--- a/commands/audit.js
+++ b/commands/audit.js
@@ -1,5 +1,5 @@
 var async = require('async');
-var audit = require('nsp/lib/auditPackage');
+var audit = require('nsp/lib/check');
 var join = require('path').join;
 
 module.exports = {


### PR DESCRIPTION
got 
```
"error requiring command file: /Users/hustler/.nvm/v4.2.2/lib/node_modules/bosco/commands/audit.js: Error: Cannot find module 'nsp/lib/auditPackage' error
```
when running bosco --version

