### PR TITLE
Only run the current project when in service folder

### DIFF
--- a/bin/bosco.js
+++ b/bin/bosco.js
@@ -14,65 +14,7 @@ var pkg = require('../package.json');
 
 var bosco = new Bosco();
 
-var globalOptions = [
-  {
-    name: 'configFile',
-    alias: 'c',
-    type: 'string',
-    desc: 'Path to bosco config file',
-  },
-  {
-    name: 'configDir',
-    alias: ['p', 'configPath'],
-    type: 'string',
-    desc: 'Path to bosco config directory',
-  },
-  {
-    name: 'environment',
-    alias: 'e',
-    type: 'string',
-    default: 'local',
-    desc: 'Set environment to use',
-  },
-  {
-    name: 'service',
-    alias: 's',
-    type: 'boolean',
-    desc: 'Run only with service in cwd (if bosco-service.json file exists in cwd)',
-  },
-  {
-    name: 'build',
-    alias: 'b',
-    type: 'string',
-    default: 'default',
-    desc: 'Set build identifier to use',
-  },
-  {
-    name: 'repo',
-    alias: 'r',
-    type: 'string',
-    default: '.*',
-    desc: 'Use a specific repository (parsed as regexp)',
-  },
-  {
-    name: 'noprompt',
-    alias: 'n',
-    type: 'boolean',
-    desc: 'Do not prompt for confirmation',
-  },
-  {
-    name: 'force',
-    alias: 'f',
-    type: 'boolean',
-    desc: 'Force over ride on publish even if no changes',
-  },
-  {
-    name: 'install-missing',
-    alias: 'i',
-    type: 'boolean',
-    desc: 'Install missing node versions via nvm',
-  },
-];
+var globalOptions = require('../config/options.json');
 
 function addCommandOptions(args, command) {
   var cmdArgs = args.wrap(null);

--- a/commands/run.js
+++ b/commands/run.js
@@ -6,6 +6,7 @@ var RunListHelper = require('../src/RunListHelper');
 var NodeRunner = require('../src/RunWrappers/Node');
 var DockerRunner = require('../src/RunWrappers/Docker');
 var DockerComposeRunner = require('../src/RunWrappers/DockerCompose');
+var CmdHelper = require('../src/CmdHelper');
 
 var runningServices = [];
 var notRunningServices = [];
@@ -47,6 +48,16 @@ function cmd(bosco, args, allDone) {
   if (bosco.options.list) {
     repos = bosco.options.list.split(',');
   } else {
+    var onWorkspaceFolder = bosco.options.workspace === process.cwd();
+    var hasDefaultRepoOption = !bosco.options.repo || CmdHelper.isDefaulOption('repo', bosco.options.repo);
+    var hasDefaultTagOption = !bosco.options.tag || CmdHelper.isDefaulOption('tag', bosco.options.tag);
+
+    // Tag and repo options take precendence over cwd
+    if (!onWorkspaceFolder && hasDefaultRepoOption && hasDefaultTagOption) {
+      bosco.options.service = true;
+      bosco.checkInService();
+    }
+
     repos = bosco.getRepos();
   }
 

--- a/config/options.json
+++ b/config/options.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "configFile",
+    "alias": "c",
+    "type": "string",
+    "desc": "Path to bosco config file"
+  }, {
+    "name": "configDir",
+    "alias": ["p", "configPath"],
+    "type": "string",
+    "desc": "Path to bosco config directory"
+  }, {
+    "name": "environment",
+    "alias": "e",
+    "type": "string",
+    "default": "local",
+    "desc": "Set environment to use"
+  }, {
+    "name": "service",
+    "alias": "s",
+    "type": "boolean",
+    "desc": "Run only with service in cwd (if bosco-service.json file exists in cwd)"
+  }, {
+    "name": "build",
+    "alias": "b",
+    "type": "string",
+    "default": "default",
+    "desc": "Set build identifier to use"
+  }, {
+    "name": "repo",
+    "alias": "r",
+    "type": "string",
+    "default": ".*",
+    "desc": "Use a specific repository (parsed as regexp)"
+  }, {
+    "name": "noprompt",
+    "alias": "n",
+    "type": "boolean",
+    "desc": "Do not prompt for confirmation"
+  }, {
+    "name": "force",
+    "alias": "f",
+    "type": "boolean",
+    "desc": "Force over ride on publish even if no changes"
+  }, {
+    "name": "install-missing",
+    "alias": "i",
+    "type": "boolean",
+    "desc": "Install missing node versions via nvm"
+  }
+]

--- a/src/CmdHelper.js
+++ b/src/CmdHelper.js
@@ -2,6 +2,7 @@ var async = require('async');
 var _ = require('lodash');
 var spawn = require('child_process').spawn;
 var hl = require('highland');
+var globalRunOptions = require('../config/options');
 
 function guardFn(bosco, repoPath, options, next) {
   next();
@@ -140,8 +141,15 @@ function iterate(bosco, options, next) {
   });
 }
 
+function isDefaulOption(option, value) {
+  var configOption = _.find(globalRunOptions, { name: option });
+
+  return configOption && configOption.default === value;
+}
+
 module.exports = {
   createOptions: createOptions,
   iterate: iterate,
   execute: execute,
+  isDefaulOption: isDefaulOption,
 };


### PR DESCRIPTION
I've seen way too many people `bosco run`ning the s***t out of 70 repos when all they wanted to do was run the project on their cwd. 

Note that we will still run all if you call `bosco run` from the workspace root folder

@geophree 