### PR TITLE
fix watch when the file is deleted instead of modifying

### DIFF
--- a/commands/cdn.js
+++ b/commands/cdn.js
@@ -177,13 +177,16 @@ function cmd(bosco, args) {
     watch.createMonitor(bosco.getOrgPath(), {filter: filterFn, ignoreDotFiles: true, ignoreUnreadableDir: true, ignoreDirectoryPattern: /node_modules|\.git|coverage/, interval: 1000}, function(monitor) {
       bosco.log('Watching ' + _.keys(monitor.files).length + ' files ...');
 
-      monitor.on('changed', function(f) {
+      function onChange(f) {
         var fileKey = watchSet[f];
 
         if (reloading[fileKey]) return;
         reloading[fileKey] = true;
         reloadFile(fileKey);
-      });
+      }
+
+      monitor.on('changed', onChange);
+      monitor.on('created', onChange);
     });
   }
 


### PR DESCRIPTION
So projects they delete before generating, so watching will ignore those files... Listening to the created and change event fix the issue. Should fix issue as well #123