### PR TITLE
Add browser sync

### DIFF
--- a/commands/cdn.js
+++ b/commands/cdn.js
@@ -106,7 +106,7 @@ function cmd(bosco, args) {
 
       if (isAsset(asset.path)) {
         fs.readFile(asset.path, function(err, content) {
-          response.end(content.toString());
+          response.end(content);
         });
       } else {
         response.end(asset.content || asset.data);

--- a/config/options.json
+++ b/config/options.json
@@ -47,5 +47,15 @@
     "alias": "i",
     "type": "boolean",
     "desc": "Install missing node versions via nvm"
+  }, {
+    "name": "browser-sync",
+    "alias": "l",
+    "type": "boolean",
+    "desc": "Enable browser-sync on cdn"
+  }, {
+    "name": "browser-sync-proxy",
+    "type": "string",
+    "default": "http://local.tescloud.com:5000",
+    "desc": "Change the url browser-sync proxies to"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "appdirectory": "^0.1.0",
     "asciify": "^1.3.5",
     "async": "^1.4.2",
+    "browser-sync": "^2.11.2",
     "clean-css": "^3.1.9",
     "cli-table": "^0.3.0",
     "colors": "^1.0.3",


### PR DESCRIPTION
under -l or --browser-sync option, proxied to local page composer

```
bosco cdn -w app-home -l
```

simplest addition of live reload I could think of adding without impacting every projects build chain

we should look at gulp builds as currently the fact it wipes out *all* assets on a change forces a page refresh, if it was more selective (e.g. only building css if css changes) it would use the inject / live-reload instead of the page refresh

![Alt Text](http://g.recordit.co/HFrS3A1ess.gif)