### PR TITLE
[Feature] Add support for github enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ At the end of this sequence of steps you will have:
 * Any dependent modules linked between projects (e.g. if one repo is actually a module depended on by another).
 * All projects fully npm installed.
 
+### Github enterprise support
+
+In order to use Bosco with your github enterprise account an additional parameter is avaialable in the bosco config file.
+
+````
+apiHostname: "your.enterprise.hostname/api/v3"
+````
+
+
 ## To join a new team
 
 ```

--- a/commands/clone.js
+++ b/commands/clone.js
@@ -164,7 +164,7 @@ function cmd(bosco, args, next) {
   var team = bosco.getTeam();
   var teamConfig = bosco.config.get('teams:' + team);
 
-  var client = github.client(bosco.config.get('github:authToken'));
+  var client = github.client(bosco.config.get('github:authToken'), {hostname: bosco.config.get('github:apiHostname') });
 
   if (!teamConfig) {
     // The user does not have a team, so just treat the repos config

--- a/commands/team.js
+++ b/commands/team.js
@@ -56,7 +56,7 @@ function getTeams(client, cb) {
 }
 
 function syncTeams(bosco, next) {
-  var client = github.client(bosco.config.get('github:authToken'));
+  var client = github.client(bosco.config.get('github:authToken'), {hostname: bosco.config.get('github:apiHostname')});
   var currentTeams = bosco.config.get('teams') || {};
   var added = 0;
 

--- a/src/RunListHelper.js
+++ b/src/RunListHelper.js
@@ -93,7 +93,7 @@ function getRepoRunList(/* Same arguments as above */) {
 function getServiceConfigFromGithub(bosco, repo, next) {
   var team = bosco.getTeam();
   var organisation = team.split('/')[0];
-  var client = github.client(bosco.config.get('github:authToken'));
+  var client = github.client(bosco.config.get('github:authToken'), {hostname: bosco.config.get('github:apiHostname')});
   var githubRepo = organisation + '/' + repo;
   var configKey = 'cache:github:' + githubRepo;
   var cachedConfig = bosco.config.get(configKey);


### PR DESCRIPTION
This Pull Request enable the support for github enterprise with dosco.

I'm just leveraging the basic capabilities of octonode to pass in an hostname for the enterprise. 
If it's not filled in (the default case),it will default to standard github.

Thanks :)