### PR TITLE
Log if no access to service config

### DIFF
--- a/src/RunListHelper.js
+++ b/src/RunListHelper.js
@@ -104,7 +104,10 @@ function getServiceConfigFromGithub(bosco, repo, next) {
     var ghrepo = client.repo(githubRepo);
     bosco.log('Retrieving ' + 'bosco-service.json'.green + ' config from github @ ' + githubRepo.cyan);
     ghrepo.contents('bosco-service.json', function(err, contents) {
-      if (err) { return next(err); }
+      if (err) {
+        bosco.log('Failed to get service config - does bosco have access?', err);
+        return next(err);
+      }
       var content = new Buffer(contents.content, 'base64');
       var config = JSON.parse(content.toString());
       bosco.config.set(configKey, config);


### PR DESCRIPTION
A log line to make it clear that there's been a failure to load the service config. Doesn't stop the continuation of the running of the command in progress. 