### PR TITLE
Renamed bosco run --dont to bosco run --dev

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -14,7 +14,7 @@ var notRunningServices = [];
 module.exports = {
   name: 'run',
   description: 'Runs all of the microservices (or subset based on regex pattern)',
-  usage: '[-r <repoPattern>] [-t <tag>]',
+  usage: '[-r <repoPattern>] [-t <tag>] [-d]',
   requiresNvm: true,
   options: [{
     name: 'tag',
@@ -35,10 +35,10 @@ module.exports = {
     desc: 'Start a list of repos (comma separated)',
   },
   {
-    name: 'dont',
+    name: 'dev',
     alias: 'd',
     type: 'boolean',
-    desc: 'Do not start current repo',
+    desc: 'Does not start current repo, use when you want to start it manually',
   }],
 };
 

--- a/commands/run.js
+++ b/commands/run.js
@@ -35,7 +35,7 @@ module.exports = {
     desc: 'Start a list of repos (comma separated)',
   },
   {
-    name: 'dev',
+    name: 'deps-only',
     alias: 'd',
     type: 'boolean',
     desc: 'Only start the dependencies of the current repo, not itself',

--- a/commands/run.js
+++ b/commands/run.js
@@ -38,7 +38,7 @@ module.exports = {
     name: 'dev',
     alias: 'd',
     type: 'boolean',
-    desc: 'Does not start current repo, use when you want to start it manually',
+    desc: 'Only start the dependencies of the current repo, not itself',
   }],
 };
 


### PR DESCRIPTION
Renamed --dont to --dev as the common case is that you don't want to start the service automatically when you are actively developing that specific service