### PR TITLE
Migrated pre-commit checks from `pre-commit` to `husky`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,9 @@
     "coverage": "istanbul cover --include-all-sources true _mocha",
     "check-coverage": "npm run coverage && istanbul check-coverage --statements 16",
     "coveralls": "npm run coverage && npm run coveralls-after-test",
-    "coveralls-after-test": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "coveralls-after-test": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "precommit": "npm run lint && npm run test"
   },
-  "pre-commit": [
-    "lint",
-    "test"
-  ],
   "keywords": [
     "micro",
     "service",
@@ -108,9 +105,9 @@
     "expect.js": "^0.3.1",
     "gulp": "^3.8.7",
     "gulp-marked-man": "^0.3.1",
+    "husky": "^0.11.4",
     "istanbul": "^0.3.2",
     "mocha": "^2.2.1",
-    "pre-commit": "^1.1.1",
     "sinon": "^1.17.1"
   },
   "config": {


### PR DESCRIPTION
Migrated pre-commit checks from `pre-commit` to `husky` for better nvm support