### PR TITLE
Modify start and stop to speed up by running things more in parallel

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -131,8 +131,8 @@ function cmd(bosco, args, allDone) {
       var nodeApps = _.filter(runList, function(i) { return i.service.type === 'node' && !_.startsWith('service-', i.name); });
       async.mapSeries([
           {services: infraServices, limit: bosco.concurrency.cpu},
-          {services: nodeServices, limit: bosco.concurrency.network},
-          {services: nodeApps, limit: bosco.concurrency.network},
+          {services: nodeServices, limit: bosco.concurrency.cpu},
+          {services: nodeApps, limit: bosco.concurrency.cpu},
       ], runServices, next);
     });
   }

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -60,12 +60,12 @@ function cmd(bosco, args, done) {
 
   function stopRunningServices(cb) {
     RunListHelper.getRunList(bosco, repos, repoRegex, null, repoTag, function(err, services) {
-      async.mapSeries(services, function(boscoService, next) {
+      async.mapLimit(services, bosco.concurrency.network, function(boscoService, next) {
         var repo = boscoService.name;
 
         if (!repo.match(repoRegex)) return next();
 
-        if (boscoService.service && boscoService.service.type) {
+        if (boscoService.service && boscoService.service.type !== 'remote') {
           return stopService(repo, boscoService, runningServices, next);
         }
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ Bosco.prototype.init = function(options) {
 
   self.concurrency = {
     network: self.options.cpus * 4, // network constrained
-    cpu: self.options.cpus, // cpu constrained
+    cpu: self.options.cpus - 1, // cpu constrained
   };
 
   events.EventEmitter.call(this);

--- a/src/RunListHelper.js
+++ b/src/RunListHelper.js
@@ -42,6 +42,8 @@ function getRunConfig(bosco, repo, watchRegex) {
     }
   }
 
+  svcConfig.service.type = svcConfig.service.type || 'remote';
+
   return svcConfig;
 }
 

--- a/src/RunWrappers/Docker.js
+++ b/src/RunWrappers/Docker.js
@@ -131,7 +131,7 @@ Runner.prototype.matchWithoutVersion = function(a, b) {
 };
 
 Runner.prototype.containerNameMatches = function(container, name) {
-  return _.any(container.Names, function(val) {
+  return _.some(container.Names, function(val) {
     return val === '/' + name;
   });
 };

--- a/src/RunWrappers/DockerUtils.js
+++ b/src/RunWrappers/DockerUtils.js
@@ -151,17 +151,14 @@ function startContainer(bosco, docker, fqn, options, container, next) {
     function check() {
       checkRunning(checkPort, checkHost, function(err, running) {
         if (!err && running) {
-          process.stdout.write('\n');
           return next();
         }
 
         if (Date.now() > checkEnd) {
-          process.stdout.write('\n');
           bosco.warn('Could not detect if ' + options.name.green + ' had started on port ' + ('' + checkPort).magenta + ' after ' + checkTimeout + 'ms');
           return next();
         }
 
-        process.stdout.write('.');
         setTimeout(check, 50);
       });
     }


### PR DESCRIPTION
Break the start process up into three groups:

- Docker services
- Node services
- Node apps

Start each group in series, but within each group start each thing in parallel up to cpu limit.  Initially did crazy things with Docker when trying to start 8 docker containers at once, but seems ok now.

## Datas

On `app-home`, which has the following set of services when started:

```
┌────────────────────────────────────────────────────────────┬──────────┬──────────┬────────────┬──────────┐
│ Node Service                                               │ PID      │ Status   │ Mode       │ Watch    │
│ service-page-composer                                      │ 40855    │ online   │ fork_mode  │          │
│ service-site-assets                                        │ 37789    │ online   │ fork_mode  │          │
│ app-resource-hub                                           │ 40706    │ online   │ fork_mode  │          │
│ service-authentication                                     │ 0        │ errored  │ fork_mode  │          │
│ service-social-hub                                         │ 38840    │ online   │ fork_mode  │          │
│ app-user-profile                                           │ 0        │ errored  │ fork_mode  │          │
│ app-authentication                                         │ 0        │ errored  │ fork_mode  │          │
│ app-home                                                   │ 40875    │ online   │ fork_mode  │          │
└────────────────────────────────────────────────────────────┴──────────┴──────────┴────────────┴──────────┘

[02:43:36] Bosco: Running Docker Images:
┌─────────────────────────┬────────────────────┬────────────────────────────────────────────────────────────┐
│ Docker Service          │ Status             │ FQN                                                        │
│ infra-rabbitmq          │ Up 53 seconds      │ docker-registry.tescloud.com/tescloud/infra-rabbitmq:late… │
│ infra-cassandra         │ Up 53 seconds      │ docker-registry.tescloud.com/tescloud/infra-cassandra:lat… │
│ infra-mysql             │ Up 53 seconds      │ docker-registry.tescloud.com/tescloud/infra-mysql:latest   │
│ infra-nginx-gateway     │ Up 53 seconds      │ docker-registry.tescloud.com/tescloud/infra-nginx-gateway… │
│ infra-redis             │ Up 53 seconds      │ docker-registry.tescloud.com/tescloud/infra-redis:latest   │
│ infra-mongodb           │ Up 53 seconds      │ docker-registry.tescloud.com/tescloud/infra-mongodb:latest │
└─────────────────────────┴────────────────────┴────────────────────────────────────────────────────────────┘
```

## Previous Bosco version

```
bosco start  3.43s user 1.26s system 11% cpu 39.738 total
```

```
bosco stop  1.45s user 0.24s system 31% cpu 5.313 total
```

## This PR

```
bosco start  3.71s user 1.36s system 38% cpu 13.284 total
```

```
bosco stop  1.71s user 0.21s system 59% cpu 3.259 total
```

## Net result

Start time:  27 seconds faster
Stop time:  2 seconds faster
