### PR TITLE
Refactor of external build to make the output cleaner

### DIFF
--- a/index.js
+++ b/index.js
@@ -516,6 +516,7 @@ Bosco.prototype._log = function(identifier, msg, args) {
 };
 
 Bosco.prototype.console = global.console;
+Bosco.prototype.process = global.process;
 
 Bosco.prototype.exists = function(checkPath) {
   return fs.existsSync(checkPath);

--- a/src/ExternalBuild.js
+++ b/src/ExternalBuild.js
@@ -1,23 +1,25 @@
-var exec = require('child_process').exec;
-var execFile = require('child_process').execFile;
-var spawn = require('child_process').spawn;
 var NodeRunner = require('./RunWrappers/Node');
+var SpawnWatch = require('./ExternalBuilders/SpawnWatch');
+var ExecBuild = require('./ExternalBuilders/ExecBuild');
+var BuildUtils = require('./ExternalBuilders/utils');
 
 module.exports = function(bosco) {
   function doBuild(service, options, interpreter, next) {
     if (!service.build) return next();
 
-    var watchBuilds = options.watchBuilds;
-    var command = service.build.command;
-    var commandForLog = command;
-    var cwd = {cwd: service.repoPath};
-    var arrayCommand = Array.isArray(command);
+    var buildUtils = new BuildUtils(bosco);
+    var execBuildCommand = new ExecBuild(bosco);
+    var spawnWatchCommand = new SpawnWatch(bosco);
     var verbose = bosco.options.verbose;
-    var args;
+    var watchingService = options.watchBuilds && !!service.name.match(options.watchRegex);
+    var command = buildUtils.createCommand(service.build, interpreter, watchingService);
+    var cwd = {cwd: service.repoPath};
+    var firstBuildCalledBack = false;
 
-    var buildFinished = function(err, stdout, stderr) {
+    function buildFinished(err, stdout, stderr) {
       // watch stderr output isn't considered fatal
       var realError = (err && err !== true) ? err : null;
+      var hasError = err || stderr;
       var log;
       if (realError) {
         log = 'Failed'.red + ' build command for ' + service.name.blue;
@@ -25,43 +27,25 @@ module.exports = function(bosco) {
           log += ' exited with code ' + err.code;
           if (err.signal !== null) log += ' and signal ' + err.signal;
         }
-
         if (stderr || stdout) log += ':';
-
         bosco.error(log);
       } else {
         log = 'Finished build command for ' + service.name.blue;
-        if (stderr || stdout) log += ':';
-
+        if (hasError && !verbose) log += ':';
         bosco.log(log);
       }
-
-      if (err || stderr || verbose) {
+      if (hasError && !verbose) {
         if (stdout) bosco.console.log(stdout);
         if (stderr) bosco.error(stderr);
       }
-
-      next(realError);
-    };
-
-    if (arrayCommand) {
-      commandForLog = JSON.stringify(command);
-      args = command;
-      command = args.shift();
-    }
-
-    function ensureCorrectNodeVersion(rawCommand) {
-      return (interpreter ? bosco.options.nvmUse : bosco.options.nvmUseDefault) + rawCommand;
-    }
-
-    command = ensureCorrectNodeVersion(command);
-
-    if (!watchBuilds || !service.name.match(options.watchRegex)) {
-      bosco.log('Running build command for ' + service.name.blue + ': ' + commandForLog);
-      if (arrayCommand) {
-        return execFile(command, args, cwd, buildFinished);
+      if (!firstBuildCalledBack) {
+        firstBuildCalledBack = true;
+        next(realError);
       }
-      return exec(command, cwd, buildFinished);
+    }
+
+    if (!watchingService) {
+      return execBuildCommand(service, command, cwd, verbose, buildFinished);
     }
 
     if (options.reloadOnly) {
@@ -69,85 +53,12 @@ module.exports = function(bosco) {
       return next();
     }
 
-    var readyText = 'finished';
-    var checkDelay = 500; // delay before checking for any stdout
-    if (service.build.watch) {
-      readyText = service.build.watch.ready || readyText;
-      checkDelay = service.build.watch.checkDelay || checkDelay;
-      if (service.build.watch.command) {
-        var watchCommand = service.build.watch.command;
-        commandForLog = watchCommand;
-        command = ensureCorrectNodeVersion(watchCommand);
-      }
+    if (watchingService) {
+      return spawnWatchCommand(service, command, cwd, verbose, buildFinished);
     }
 
-    bosco.log('Spawning ' + 'watch'.red + ' command for ' + service.name.blue + ': ' + commandForLog);
-
-    var wc = spawn(process.env.SHELL, ['-c', command], cwd);
-    var output = '';
-    var childError = null;
-    var calledReady = false;
-    var timeout = checkDelay * 100; // Seems reasonable for build cycle
-    var timer = 0;
-    var watchBuildFinished;
-
-    function checkFinished() {
-      if (calledReady) return null;
-
-      if (childError && childError !== true) {
-        return watchBuildFinished(childError, '', output);
-      }
-
-      if (output.indexOf(readyText) >= 0) {
-        return watchBuildFinished(childError, output);
-      }
-
-      timer = timer + checkDelay;
-      if (timer < timeout) return setTimeout(checkFinished, checkDelay);
-
-      bosco.error('Build timed out beyond ' + timeout / 1000 + ' seconds, likely an issue with the project build - you may need to check locally. Was looking for: ' + readyText);
-
-      childError = new Error('build timed out beyond ' + timeout / 1000 + ' seconds');
-      wc.kill();
-      checkFinished();
-    }
-
-    wc.on('exit', function(code, signal) {
-      if (!childError || childError === true) {
-        // any exit of a watch process is an error.
-        childError = new Error('Watch process exited with code ' + code + ' and signal ' + signal);
-        childError.code = code;
-        childError.signal = signal;
-      }
-
-      if (calledReady) {
-        bosco.error('Watch'.red + ' command for ' + service.name.blue + ' died with code ' + code);
-      }
-    });
-
-    wc.stdout.on('data', function(data) {
-      if (!calledReady) {
-        output += data.toString();
-      }
-    });
-
-    watchBuildFinished = function() {
-      clearTimeout(checkFinished);
-      calledReady = true;
-      output = '';
-      buildFinished.apply(this, arguments);
-    };
-
-    wc.stderr.on('data', function(data) {
-      childError = true;
-      if (calledReady) {
-        bosco.error('Watch'.red + ' command for ' + service.name.blue + ' stderr:\n' + data.toString());
-      } else {
-        output += data.toString();
-      }
-    });
-
-    checkFinished();
+    // No matching execution, nothing to build
+    return next();
   }
 
   function doBuildWithInterpreter(service, options, next) {

--- a/src/ExternalBuilders/ExecBuild.js
+++ b/src/ExternalBuilders/ExecBuild.js
@@ -1,0 +1,12 @@
+var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
+
+module.exports = function(bosco) {
+  return function(service, command, cwd, verbose, buildFinished) {
+    bosco.log('Running build command for ' + service.name.blue + ': ' + command.log);
+    if (command.args) {
+      return execFile(command.command, command.args, cwd, buildFinished);
+    }
+    return exec(command.command, cwd, buildFinished);
+  };
+};

--- a/src/ExternalBuilders/SpawnWatch.js
+++ b/src/ExternalBuilders/SpawnWatch.js
@@ -1,0 +1,77 @@
+var spawn = require('child_process').spawn;
+
+module.exports = function(bosco) {
+  return function(service, command, cwd, verbose, buildFinished) {
+    bosco.log('Spawning ' + 'watch'.red + ' command for ' + service.name.blue + ': ' + command.log);
+    var wc = spawn(process.env.SHELL, ['-c', command.command], cwd);
+    var output = '';
+    var errorOutput = '';
+    var childError = null;
+    var checkFinishedTimer;
+    var overallTimeout;
+    var waitingForOutput = true;
+
+    var watchBuildFinished = function(err, stdout, stderr) {
+      clearTimeout(checkFinishedTimer);
+      clearTimeout(overallTimeout);
+      checkFinishedTimer = null;
+      waitingForOutput = true;
+      output = '';
+      errorOutput = '';
+      buildFinished(err, stdout, stderr);
+    };
+
+    var checkFinished = function() {
+      if (childError && childError !== true) {
+        return watchBuildFinished(childError, output, errorOutput);
+      }
+      if (output.indexOf(command.ready) >= 0) {
+        return watchBuildFinished(childError, output);
+      }
+      checkFinishedTimer = setTimeout(checkFinished, command.checkDelay);
+    };
+
+    overallTimeout = setTimeout(function() {
+      clearTimeout(checkFinishedTimer);
+      bosco.error('Build timed out beyond ' + command.timeout / 1000 + ' seconds, likely an issue with the project build - you may need to check locally. Was looking for: ' + command.ready);
+      childError = new Error('build timed out beyond ' + command.timeout / 1000 + ' seconds');
+      wc.kill();
+      return watchBuildFinished(childError, '', output);
+    }, command.timeout);
+
+    wc.on('exit', function(code, signal) {
+      if (!childError || childError === true) {
+        // any exit of a watch process is an error.
+        childError = new Error('Watch process exited with code ' + code + ' and signal ' + signal);
+        childError.code = code;
+        childError.signal = signal;
+      }
+      bosco.error('Watch'.red + ' command for ' + service.name.blue + ' died with code ' + code);
+    });
+
+    wc.stdout.on('data', function(data) {
+      if (waitingForOutput) {
+        if (!checkFinishedTimer) checkFinished();
+        waitingForOutput = false;
+        bosco.log('Started build for service ' + service.name.blue + ' ...');
+      }
+      output += data.toString();
+      if (verbose) {
+        process.stdout.write(data.toString());
+      }
+    });
+
+    wc.stderr.on('data', function(data) {
+      if (waitingForOutput) {
+        if (!checkFinishedTimer) checkFinished();
+        waitingForOutput = false;
+        bosco.log('Started build for service ' + service.name.blue + ', but immediately errored ...');
+      }
+      childError = true;
+      errorOutput += data.toString();
+      if (verbose) {
+        process.stdout.write(data.toString());
+      }
+    });
+  };
+};

--- a/src/ExternalBuilders/SpawnWatch.js
+++ b/src/ExternalBuilders/SpawnWatch.js
@@ -18,9 +18,9 @@ module.exports = function(bosco) {
     }
 
     function buildCompleted(err) {
-      var rtn = buildFinished(err, output);
+      var outputToReturn = output;
       reset();
-      return rtn;
+      return buildFinished(err, outputToReturn);
     }
 
     function onBuildTimeout() {

--- a/src/ExternalBuilders/utils.js
+++ b/src/ExternalBuilders/utils.js
@@ -1,0 +1,37 @@
+module.exports = function(bosco) {
+  function ensureCorrectNodeVersion(rawCommand, interpreter) {
+    return (interpreter ? bosco.options.nvmUse : bosco.options.nvmUseDefault) + rawCommand;
+  }
+
+  function createCommand(buildConfig, interpreter, watch) {
+    var commandForLog;
+    var command;
+    var ready;
+    var checkDelay;
+    var timeout;
+    var args;
+    if (watch) {
+      var watchConfig = buildConfig.watch || {};
+      ready = watchConfig.ready || 'finished';
+      checkDelay = watchConfig.checkDelay || 500;
+      timeout = watchConfig.timeout || checkDelay * 100;
+      command = watchConfig.command || buildConfig.command;
+      commandForLog = command;
+    } else {
+      command = buildConfig.command;
+      commandForLog = command;
+      var arrayCommand = Array.isArray(command);
+      if (arrayCommand) {
+        commandForLog = JSON.stringify(command);
+        args = command;
+        command = args.shift();
+      }
+    }
+    command = ensureCorrectNodeVersion(command, interpreter);
+    return {command: command, args: args, log: commandForLog, watch: watch, ready: ready, checkDelay: checkDelay, timeout: timeout};
+  }
+
+  return {
+    createCommand: createCommand,
+  };
+};

--- a/test/ExternalBuild.test.js
+++ b/test/ExternalBuild.test.js
@@ -209,9 +209,9 @@ describe('ExternalBuild', function() {
       name: 'service',
       repoPath: localBosco.getRepoPath(''),
       build: {
-        command: ['echo -n build; echo -n bye >&2;false'],
+        command: ['echo -n build >&2;false'],
         watch: {
-          command: ['echo -n watch; echo -n bye >&2;sleep 1;false'],
+          command: ['echo -n watch >&2;sleep 1;false'],
           ready: 'watch',
           checkDelay: 10
         }
@@ -224,7 +224,9 @@ describe('ExternalBuild', function() {
 
     doBuild(service, options, null, function(err) {
       if (err) return done(err);
-      expect(localBosco.console._log).to.eql(['watch']);
+      expect(localBosco.process.stderr).to.have.property('_data');
+      expect(localBosco.process.stderr._data).to.eql(['watch']);
+      expect(localBosco.process.stdout).to.not.have.property('_data');
       expect(localBosco).to.have.property('_log');
       expect(localBosco).to.not.have.property('_error');
       done();

--- a/test/ExternalBuild.test.js
+++ b/test/ExternalBuild.test.js
@@ -127,7 +127,7 @@ describe('ExternalBuild', function() {
         command: 'echo hi; sleep 1',
         watch: {
           ready: 'hi',
-          checkDelay: 10
+          checkDelay: 1
         }
       }
     };
@@ -138,12 +138,9 @@ describe('ExternalBuild', function() {
 
     doBuild(service, options, null, function(err) {
       if (err) return done(err);
-
       expect(localBosco.console).to.not.have.property('_log');
       expect(localBosco._log).to.be.an('array');
-      expect(localBosco._log).to.have.length(2);
       expect(localBosco._log[0]).to.contain('echo hi; sleep 1');
-
       done();
     });
   });
@@ -172,8 +169,7 @@ describe('ExternalBuild', function() {
       expect(err).to.have.property('code', 0);
       expect(localBosco._error).to.be.an('array');
       expect(localBosco._error).to.have.length(2);
-      expect(localBosco._error[0]).to.contain('with code 0');
-      expect(localBosco._error[1]).to.be('\n');
+      expect(localBosco._error[1]).to.contain('with code 0');
       done();
     });
   });
@@ -185,7 +181,7 @@ describe('ExternalBuild', function() {
       name: 'service',
       repoPath: localBosco.getRepoPath(''),
       build: {
-        command: 'sleep 1',
+        command: 'echo hello; sleep 1',
         watch: {
           checkDelay: 1
         }
@@ -228,7 +224,7 @@ describe('ExternalBuild', function() {
 
     doBuild(service, options, null, function(err) {
       if (err) return done(err);
-      expect(localBosco.console._log).to.eql(['watchbye']);
+      expect(localBosco.console._log).to.eql(['watch']);
       expect(localBosco).to.have.property('_log');
       expect(localBosco).to.not.have.property('_error');
       done();

--- a/test/TestOrganisation/projectFail/bosco-service.json
+++ b/test/TestOrganisation/projectFail/bosco-service.json
@@ -4,7 +4,7 @@
     "name": "project3"
   },
   "build": {
-    "command": "false",
+    "command": "echo blah; false",
     "watch": {
       "checkDelay": 10
     }

--- a/test/boscoMock.js
+++ b/test/boscoMock.js
@@ -6,13 +6,21 @@ function getLogger() {
   return {
     log: function(msg) { this._log = this._log || []; this._log.push(msg); },
     error: function(msg) { this._error = this._error || []; this._error.push(msg); },
-    warn: function(msg) { this._warn = this._warn || []; this._warn.push(msg); }
+    warn: function(msg) { this._warn = this._warn || []; this._warn.push(msg); },
+  };
+}
+
+function getProcess() {
+  return {
+    stdout: { write: function(msg) { this._data = this._data || []; this._data.push(msg); } },
+    stderr: { write: function(msg) { this._data = this._data || []; this._data.push(msg); } },
   };
 }
 
 module.exports = function boscoMock(extra) {
   return _.assign({}, getLogger(), {
     console: getLogger(),
+    process: getProcess(),
     repos: [],
     options: {
       environment: 'test',


### PR DESCRIPTION
Rolls up output changes from @bettiolo, should make ongoing watching and console output much more usable. 