### PR TITLE
Removing unused option `checkDelay`

### DIFF
--- a/src/ExternalBuilders/utils.js
+++ b/src/ExternalBuilders/utils.js
@@ -7,14 +7,12 @@ module.exports = function(bosco) {
     var commandForLog;
     var command;
     var ready;
-    var checkDelay;
     var timeout;
     var args;
     if (watch) {
       var watchConfig = buildConfig.watch || {};
       ready = watchConfig.ready || 'finished';
-      checkDelay = watchConfig.checkDelay || 500;
-      timeout = watchConfig.timeout || checkDelay * 100;
+      timeout = watchConfig.timeout || 10000;
       command = watchConfig.command || buildConfig.command;
       commandForLog = command;
     } else {
@@ -28,7 +26,7 @@ module.exports = function(bosco) {
       }
     }
     command = ensureCorrectNodeVersion(command, interpreter);
-    return {command: command, args: args, log: commandForLog, watch: watch, ready: ready, checkDelay: checkDelay, timeout: timeout};
+    return {command: command, args: args, log: commandForLog, watch: watch, ready: ready, timeout: timeout};
   }
 
   return {

--- a/test/ExternalBuild.test.js
+++ b/test/ExternalBuild.test.js
@@ -127,7 +127,6 @@ describe('ExternalBuild', function() {
         command: 'echo hi; sleep 1',
         watch: {
           ready: 'hi',
-          checkDelay: 1
         }
       }
     };
@@ -155,7 +154,6 @@ describe('ExternalBuild', function() {
         command: 'bash -c echo',
         watch: {
           ready: 'hi',
-          checkDelay: 10
         }
       }
     };
@@ -212,8 +210,7 @@ describe('ExternalBuild', function() {
         command: ['echo -n build >&2;false'],
         watch: {
           command: ['echo -n watch >&2;sleep 1;false'],
-          ready: 'watch',
-          checkDelay: 10
+          ready: 'watch'
         }
       }
     };

--- a/test/TestOrganisation/project3/bosco-service.json
+++ b/test/TestOrganisation/project3/bosco-service.json
@@ -7,8 +7,7 @@
     "command": "echo 'This is the pseudo output of a build command.'",
     "watch": {
       "command": ["echo \"COMPLETA\"; sleep 1"],
-      "ready": "COMPLETA",
-      "checkDelay": 10
+      "ready": "COMPLETA"
     }
   },
   "assets": {

--- a/test/TestOrganisation/projectEmpty/bosco-service.json
+++ b/test/TestOrganisation/projectEmpty/bosco-service.json
@@ -4,10 +4,7 @@
     "name": "projectEmpty"
   },
   "build": {
-    "command": "echo 'This is the pseudo output of a build command.'",
-    "watch": {
-      "checkDelay": 10
-    }
+    "command": "echo 'This is the pseudo output of a build command.'"
   },
   "files": {
     "invalid-files": {

--- a/test/TestOrganisation/projectFail/bosco-service.json
+++ b/test/TestOrganisation/projectFail/bosco-service.json
@@ -4,10 +4,7 @@
     "name": "project3"
   },
   "build": {
-    "command": "echo blah; false",
-    "watch": {
-      "checkDelay": 10
-    }
+    "command": "echo blah; false"
   },
   "assets": {
     "basePath": "/dist",


### PR DESCRIPTION
`checkDelay` and related timer are not used anymore.

It has been replaced by `isBuildFinished` sync method: 
https://github.com/tes/bosco/blob/master/src/ExternalBuilders/SpawnWatch.js#L47-L62