### PR TITLE
bosco ps will now display fluid columns

### DIFF
--- a/commands/ps.js
+++ b/commands/ps.js
@@ -32,11 +32,19 @@ function cmd(bosco) {
     });
   }
 
+  function calcFluidColumnWidth(fixedColumnWidths, numberOfColumns) {
+    var minFluidColWidth = 20;
+    var fluidColWidth = process.stdout.columns - fixedColumnWidths - numberOfColumns - 1;
+    return (fluidColWidth > minFluidColWidth)
+      ? fluidColWidth
+      : minFluidColWidth;
+  }
+
   function printNodeServices(name, list) {
     var table = new Table({
       chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
       head: [name + ' Service', 'PID', 'Status', 'Mode', 'Watch'],
-      colWidths: [60, 10, 10, 12, 10],
+      colWidths: [calcFluidColumnWidth(42, 5), 10, 10, 12, 10],
     });
 
     list.forEach(function(item) {
@@ -51,7 +59,7 @@ function cmd(bosco) {
     var table = new Table({
       chars: {'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': ''},
       head: [name + ' Service', 'Status', 'FQN'],
-      colWidths: [25, 20, 60],
+      colWidths: [25, 20, calcFluidColumnWidth(45, 3)],
     });
 
     list.forEach(function(item) {


### PR DESCRIPTION
Columns will fill available terminal space until a minimum width of 20 columns:

![screen shot 2016-09-16 at 16 15 36](https://cloud.githubusercontent.com/assets/1333608/18591051/f7c18cdc-7c28-11e6-946a-36c6419c535e.png)

![screen shot 2016-09-16 at 16 16 10](https://cloud.githubusercontent.com/assets/1333608/18591050/f7b0eef4-7c28-11e6-8759-378b289d69c2.png)