### PR TITLE
add new command to report on repos not on master

### DIFF
--- a/commands/branches.js
+++ b/commands/branches.js
@@ -24,7 +24,7 @@ function cmd(bosco) {
       var activeBranch = stdout.match(/\* (.*)/)[1];
 
       if (activeBranch !== 'master') {
-        bosco.log(path.blue + ' is on branch \'' + activeBranch + '\'');
+        bosco.log(path.blue + ' is on branch \'' + activeBranch.cyan + '\'');
       }
     },
   });

--- a/commands/branches.js
+++ b/commands/branches.js
@@ -3,16 +3,16 @@ var _ = require('lodash');
 
 module.exports = {
   name: 'branches',
-  description: 'Checks git branch list across all services',
+  description: 'Checks git local branch name across all services',
   usage: '[-r <repoPattern>]',
 };
 
 function cmd(bosco) {
-  bosco.log('Running \'git branch --list\' across all matching repos ...');
+  bosco.log('Running \'git rev-parse --abbrev-ref HEAD\' across all matching repos ...');
 
   var options = ch.createOptions(bosco, {
     cmd: 'git',
-    args: ['branch', '--list'],
+    args: ['rev-parse', '--abbrev-ref', 'HEAD'],
     guardFn: function(innerBosco, repoPath, opts, next) {
       if (innerBosco.exists([repoPath, '.git'].join('/'))) return next();
       next(new Error('Doesn\'t seem to be a git repo: ' + repoPath.blue));
@@ -20,11 +20,10 @@ function cmd(bosco) {
     stdoutFn: function(stdout, path) {
       if (!stdout) return;
 
-      // find the line in the stdout with the * in front, and grab the branch name
-      var activeBranch = stdout.match(/\* (.*)/)[1];
+      var branchName = stdout.trim();
 
-      if (activeBranch !== 'master') {
-        bosco.log(path.blue + ' is on branch \'' + activeBranch.cyan + '\'');
+      if (branchName !== 'master') {
+        bosco.log(path.blue + ' is on branch \'' + branchName.cyan + '\'');
       }
     },
   });

--- a/commands/branches.js
+++ b/commands/branches.js
@@ -1,0 +1,37 @@
+var ch = require('../src/CmdHelper');
+var _ = require('lodash');
+
+module.exports = {
+  name: 'branches',
+  description: 'Checks git branch list across all services',
+  usage: '[-r <repoPattern>]',
+};
+
+function cmd(bosco) {
+  bosco.log('Running \'git branch --list\' across all matching repos ...');
+
+  var options = ch.createOptions(bosco, {
+    cmd: 'git',
+    args: ['branch', '--list'],
+    guardFn: function(innerBosco, repoPath, opts, next) {
+      if (innerBosco.exists([repoPath, '.git'].join('/'))) return next();
+      next(new Error('Doesn\'t seem to be a git repo: ' + repoPath.blue));
+    },
+    stdoutFn: function(stdout, path) {
+      if (!stdout) return;
+
+      // find the line in the stdout with the * in front, and grab the branch name
+      var activeBranch = stdout.match(/\* (.*)/)[1];
+
+      if (activeBranch !== 'master') {
+        bosco.log(path.blue + ' is on branch \'' + activeBranch + '\'');
+      }
+    },
+  });
+
+  ch.iterate(bosco, options, function() {
+    bosco.log('Complete');
+  });
+}
+
+module.exports.cmd = cmd;


### PR DESCRIPTION
based off of status command.

use 'git branch --list' to show all branches, and checked out branch is marked with a '*'

only show results for branches not on master