### PR TITLE
Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,13 @@ To serve swf, fonts or pdf, you should add them under a 'files' key (at the same
         "pdf/guide.pdf"
       ]
     }
-  }
+  },
+  "libraries": [
+    {
+        "basePath": "src/vendor",
+        "glob": "**/**"
+    }
+  ]
 }
 ```
 

--- a/src/StaticUtils.js
+++ b/src/StaticUtils.js
@@ -103,6 +103,16 @@ module.exports = function(bosco) {
       });
     }
 
+    if (boscoRepo.libraries) {
+      _.forEach(boscoRepo.libraries, function(library) {
+        var assets = globAsset(library.glob, path.join(boscoRepo.path, library.basePath));
+        _.forEach(assets, function(asset) {
+          assetKey = path.join('vendor', 'library', asset);
+          assetHelper.addAsset(staticAssets, 'library', assetKey, asset, 'vendor', 'library', library.basePath, true, {alreadyMinified: true});
+        });
+      });
+    }
+
     next(null, staticAssets);
   }
 


### PR DESCRIPTION
Define vendor libraries outside of the usual `files` or `assets`, these get pushed up to a static `vendor/library` folder that does not have the build number of the service.

Example of service:  https://github.com/tes/service-site-assets/blob/libraries-example/bosco-service.json#L21-L30

