### PR TITLE
return the list of repos, not an unresolved chain

### DIFF
--- a/commands/install.js
+++ b/commands/install.js
@@ -107,7 +107,8 @@ function cmd(bosco, args, next) {
     RunListHelper.getRepoRunList(bosco, bosco.getRepos(), repoRegex, '$^', null, function(err, runRepos) {
       repos = _.chain(runRepos)
               .filter(function(repo) { return repo.type !== 'remote'; })
-              .map('name');
+              .map('name')
+              .value();
       cb(err);
     });
   }


### PR DESCRIPTION
It's possible (likely?) I've missed something here, but the `bosco install` command now works in a single repo on my machine.

cc/ @dmorgantini @cliftonc 