### PR TITLE
utf8 encode stderr

### DIFF
--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -55,6 +55,7 @@ Runner.prototype.getInterpreter = function(bosco, options, next) {
   if (hasNvmRc) {
     var e = exec(bosco.options.nvmWhich, {cwd: options.cwd});
     e.stdout.setEncoding('utf8');
+    e.stderr.setEncoding('utf8');
 
     e.stdout.on('data', function(data) {
       if (data.indexOf('Found') === 0) {


### PR DESCRIPTION
Without this stderr can't be parsed and produces an error like:

```
error = options.name + ' nvm failed with: ' + data.replace('\n', '') + ', use -i option to install missing node versions!';
                                                             ^

TypeError: data.replace is not a function
```