### PR TITLE
Fix `help` command

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -1,4 +1,3 @@
-var path = require('path');
 var spawn = require('child_process').spawn;
 
 module.exports = {
@@ -9,21 +8,14 @@ module.exports = {
 
 // Shamelessly stolen from npm
 function viewMan(man, cb) {
-  var nre = /([0-9]+)$/;
-  var num = man.match(nre)[1];
-  var section = path.basename(man, '.' + num);
-
-  // at this point, we know that the specified man page exists
-  var manpath = path.join(__dirname, '..', 'man');
   var env = {};
 
   Object.keys(process.env).forEach(function(i) {
     env[i] = process.env[i];
   });
-  env.MANPATH = manpath;
 
-  var conf = { env: env, customFds: [ 0, 1, 2] };
-  var manProcess = spawn('man', [num, section], conf);
+  var conf = { env: env, stdio: 'inherit' };
+  var manProcess = spawn('man', [man], conf);
   manProcess.on('close', cb);
 }
 
@@ -31,7 +23,7 @@ function cmd(bosco, args) {
   var cmdName = args.shift();
   if (!cmdName) return bosco.error('You need to provide a command name. e.g: bosco help ' + module.exports.usage);
 
-  var man = 'bosco-' + cmdName + '.3';
+  var man = 'bosco-' + cmdName;
   viewMan(man, function() {});
 }
 


### PR DESCRIPTION
Since the `man` folder was [flattened](https://github.com/tes/bosco/commit/951ed2293955496add90dd12c3eac7814cd6d686) running `bosco help $cmd` gives the following error:

```
No entry for bosco-run in section 3 of the manual
```

We no longer need to set `env.MANPATH` as it has been flattened so the path will be the default. This simplifies the code a lot.

We also get a deprecation warning when running `bosco help`:

```
(node:34232) DeprecationWarning: child_process: options.customFds option is deprecated. Use options.stdio instead.
```

This PR fixes the deprecation warning by using `stdio` instead of `customFds`.