### PR TITLE
Don't crash `bosco cdn` if the project has no static assets

### DIFF
--- a/commands/cdn.js
+++ b/commands/cdn.js
@@ -102,7 +102,7 @@ function cmd(bosco, args) {
       if (!asset) {
         headers['Content-Type'] = 'text/html';
         response.writeHead(404, headers);
-        return response.end(staticAssets.formattedAssets);
+        return staticAssets ? response.end(staticAssets.formattedAssets) : response.end();
       }
 
       headers['Content-Type'] = asset.mimeType;


### PR DESCRIPTION
If running `bosco cdn` from within a project that has no assets defined in the `bosco-service.json`, it crashes with the following error:

```
[05:12:47] Bosco: Starting pseudo CDN on port: 7334

[05:12:47] Bosco: 0 out of 0 succeeded.
[05:12:47] Bosco: Server is listening on 7334
/Users/rnewstead/.nvm/versions/node/v6.2.1/lib/node_modules/bosco/commands/cdn.js:105
        return response.end(staticAssets.formattedAssets);
                                        ^

TypeError: Cannot read property 'formattedAssets' of undefined
    at Server.<anonymous> (/Users/rnewstead/.nvm/versions/node/v6.2.1/lib/node_modules/bosco/commands/cdn.js:105:41)
    at emitTwo (events.js:106:13)
    at Server.emit (events.js:191:7)
    at HTTPParser.parserOnIncoming [as onIncoming] (_http_server.js:543:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:105:23)
```

It may be unusual to run cdn from a project with no static assets, but doesn't seem that the command should error in such a way.

This fix stops the cdn from crashing by just calling `response.end()` in the case where there are no static assets.