### PR TITLE
Add simple concatenated bundles in local cdn mode to allow new inline…

### DIFF
--- a/src/Html.js
+++ b/src/Html.js
@@ -98,7 +98,7 @@ module.exports = function(bosco) {
 
     var allStaticAssets = _.union(_.values(htmlAssets), staticAssets);
 
-    allStaticAssets.formattedAssets = formattedAssets(staticAssets);
+    allStaticAssets.formattedAssets = formattedAssets(allStaticAssets);
 
     next(null, allStaticAssets);
   }

--- a/src/StaticUtils.js
+++ b/src/StaticUtils.js
@@ -168,10 +168,8 @@ module.exports = function(bosco) {
           return next();
         }
 
-        if (!options.minify) return createAssetHtmlFiles(staticAssets, next);
-
-        // Now go and minify
-        minify(staticAssets, function(err, minifiedAssets) {
+        var concatenateOnly = !options.minify;
+        minify(staticAssets, concatenateOnly, function(err, minifiedAssets) {
           if (err && !ignoreFailure) return next(err);
           createAssetHtmlFiles(minifiedAssets, next);
         });


### PR DESCRIPTION
… etc. to work in compoxure

This basically ensures that even in `bosco cdn` un-minified mode it will now actually serve the bundle, so this can be referenced and pulled in when using `cx-inline`.  It is fast as it doesn't bother uglifying / cleaning, it simply concatenates the source files, it also loads them from disk so no caching / reload issues.

@jonnywyatt @sithmel