### PR TITLE
Add --docker-only as option to bosco run command

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -46,6 +46,11 @@ module.exports = {
       type: 'boolean',
       desc: 'Display the dependency tree but do not start the services',
     },
+    {
+      name: 'docker-only',
+      type: 'boolean',
+      desc: 'Only start docker dependency',
+    },
   ],
 };
 

--- a/commands/run.js
+++ b/commands/run.js
@@ -49,7 +49,7 @@ module.exports = {
     {
       name: 'docker-only',
       type: 'boolean',
-      desc: 'Only start docker dependency',
+      desc: 'Only start docker dependencies',
     },
   ],
 };

--- a/src/RunListHelper.js
+++ b/src/RunListHelper.js
@@ -56,6 +56,10 @@ function getRunList(bosco, repos, repoRegex, watchRegex, repoTag, displayOnly) {
     return (bosco.options.inService && repo === bosco.options.inServiceRepo);
   }
 
+  function notCurrentService(repo) {
+    return !isCurrentService(repo);
+  }
+
   function getCachedConfig(repo) {
     var config = configs[repo];
     if (config) {
@@ -70,12 +74,17 @@ function getRunList(bosco, repos, repoRegex, watchRegex, repoTag, displayOnly) {
     return !isModule && (!repoTag && repo.match(repoRegex)) || (repoTag && _.includes(tags, repoTag));
   }
 
-  function notCurrentService(repo) {
-    return !(bosco.options['deps-only'] && isCurrentService(repo));
+  function isType(type) {
+    return function(repo) {
+      return getCachedConfig(repo).service.type === type;
+    };
   }
 
-  function isType(repo) {
-    return (bosco.options['docker-only'] && isCurrentService(repo));
+  function boscoOptionFilter(option, fn) {
+    if (bosco.options[option]) return fn;
+    return function() {
+      return true;
+    };
   }
 
   function matchingRepo(repo) {
@@ -119,8 +128,8 @@ function getRunList(bosco, repos, repoRegex, watchRegex, repoTag, displayOnly) {
   var runList = _.chain(repos)
     .filter(matchingRepo)
     .reduce(addDependencies, [])
-    .filter(notCurrentService)
-    .filter(isType)
+    .filter(boscoOptionFilter('deps-only', notCurrentService))
+    .filter(boscoOptionFilter('docker-only', isType('remote')))
     .map(getCachedConfig)
     .sortBy(getOrder)
     .value();

--- a/src/RunListHelper.js
+++ b/src/RunListHelper.js
@@ -74,6 +74,10 @@ function getRunList(bosco, repos, repoRegex, watchRegex, repoTag, displayOnly) {
     return !(bosco.options['deps-only'] && isCurrentService(repo));
   }
 
+  function isType(repo) {
+    return (bosco.options['docker-only'] && isCurrentService(repo));
+  }
+
   function matchingRepo(repo) {
     var config = getCachedConfig(repo);
     return matchesRegexOrTag(repo, config.tags);
@@ -116,6 +120,7 @@ function getRunList(bosco, repos, repoRegex, watchRegex, repoTag, displayOnly) {
     .filter(matchingRepo)
     .reduce(addDependencies, [])
     .filter(notCurrentService)
+    .filter(isType)
     .map(getCachedConfig)
     .sortBy(getOrder)
     .value();


### PR DESCRIPTION
'--docker-only' is an option of 'bosco run' command that starts docker only dependencies, but do not start the services.  

The use case is to restart docker only dependencies when docker crashes while all the services are already running via pm2. 