### PR TITLE
Add cache-control: immutable given we always version by URL

### DIFF
--- a/commands/s3push.js
+++ b/commands/s3push.js
@@ -46,7 +46,7 @@ function cmd(bosco, args, callback) {
   noprompt = bosco.options.noprompt;
 
   var maxAge = bosco.config.get('aws:maxage');
-  if (typeof maxAge !== 'number') maxAge = 31536000; // Default to one year
+  if (typeof maxAge !== 'number') maxAge = 365000000;
 
   bosco.log('Compile front end assets across services ' + (tag ? 'for tag: ' + tag.blue : ''));
 
@@ -125,7 +125,7 @@ function cmd(bosco, args, callback) {
       var headers = {
         'Content-Type': file.mimeType,
         'Content-Encoding': 'gzip',
-        'Cache-Control': ('max-age=' + (maxAge === 0 ? '0, must-revalidate' : maxAge)),
+        'Cache-Control': ('max-age=' + (maxAge === 0 ? '0, must-revalidate' : maxAge) + ', immutable'),
       };
       bosco.knox.putBuffer(buffer, file.path, headers, function(error, res) {
         var err = error;


### PR DESCRIPTION
https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/
https://code.facebook.com/posts/557147474482256

Can't see any risk for us given we always have the build number as part of the URL, and the file version number in the URL for any 3rd party library.

This only applies to S3 files, not to local cdn.