### PR TITLE
assign a new value for the whole svcConfig, not just the .service

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -169,7 +169,7 @@ function cmd(bosco, args, allDone) {
           RunListHelper.getServiceConfigFromGithub(bosco, runConfig.name, function(err, svcConfig) {
             if (err || !svcConfig || !svcConfig.service || !svcConfig.service.type || svcConfig.service.type !== 'docker') {
               // Create psuedo service config
-              svcConfig.service = RunListHelper.getServiceDockerConfig(runConfig, svcConfig);
+              svcConfig = { service: RunListHelper.getServiceDockerConfig(runConfig, svcConfig) };
             }
             // Do not allow build in this mode, so default to run
             if (svcConfig.service && svcConfig.service.build) {

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -88,7 +88,7 @@ function cmd(bosco, args, done) {
         }
         RunListHelper.getServiceConfigFromGithub(bosco, boscoService.name, function(err, svcConfig) {
           if (err || !svcConfig || !svcConfig.service || !svcConfig.service.type || svcConfig.service.type !== 'docker') {
-            svcConfig.service = RunListHelper.getServiceDockerConfig(boscoService, svcConfig);
+            svcConfig = { service: RunListHelper.getServiceDockerConfig(boscoService, svcConfig) };
           }
           if (!svcConfig.name) svcConfig.name = boscoService.name;
           stopService(repo, svcConfig, runningServices, next);


### PR DESCRIPTION
@cliftonc, we found that there are several repos in our teams that do not have a bosco-service.json, so `bosco start` and `bosco stop` are failing on 404s.

Given that the conditions that would get us to this code is for svcConfig to be undefined, we think that this fix might be just what we need to make it work.

It appears to work on a patched version.

@albertodotcom 