### PR TITLE
Create an empty svcConfig object to pass in getServiceDockerConfig

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -169,7 +169,8 @@ function cmd(bosco, args, allDone) {
           RunListHelper.getServiceConfigFromGithub(bosco, runConfig.name, function(err, svcConfig) {
             if (err || !svcConfig || !svcConfig.service || !svcConfig.service.type || svcConfig.service.type !== 'docker') {
               // Create psuedo service config
-              svcConfig = { service: RunListHelper.getServiceDockerConfig(runConfig, svcConfig) };
+              svcConfig = {};
+              svcConfig.service = RunListHelper.getServiceDockerConfig(runConfig, svcConfig);
             }
             // Do not allow build in this mode, so default to run
             if (svcConfig.service && svcConfig.service.build) {

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -88,7 +88,8 @@ function cmd(bosco, args, done) {
         }
         RunListHelper.getServiceConfigFromGithub(bosco, boscoService.name, function(err, svcConfig) {
           if (err || !svcConfig || !svcConfig.service || !svcConfig.service.type || svcConfig.service.type !== 'docker') {
-            svcConfig = { service: RunListHelper.getServiceDockerConfig(boscoService, svcConfig) };
+            svcConfig = {};
+            svcConfig.service = RunListHelper.getServiceDockerConfig(boscoService, svcConfig);
           }
           if (!svcConfig.name) svcConfig.name = boscoService.name;
           stopService(repo, svcConfig, runningServices, next);


### PR DESCRIPTION
This PR fixes the error that occurs when running the `run` or `stop` command by creating an empty object that is passed into getServiceDockerConfig method