### PR TITLE
added --pure-lockfile option to yarn

### DIFF
--- a/commands/install.js
+++ b/commands/install.js
@@ -24,7 +24,7 @@ function install(bosco, progressbar, bar, repoPath, repo, next) {
   var yarnrcFile = [repoPath, '.yarnrc'].join('/');
   var yarnLockFile = [repoPath, 'yarn.lock'].join('/');
   if (bosco.exists(yarnrcFile) || bosco.exists(yarnLockFile)) {
-    var yarnComamnd = 'yarn';
+    var yarnComamnd = 'yarn --pure-lockfile';
     exec(yarnComamnd, {
       cwd: repoPath,
     }, function(err, stdout, stderr) {


### PR DESCRIPTION
bosco morning runs yarn and this may update some dependency, generating a new yarn.lock.
Next time bosco morning won't pull any change because there are unstaged changes (the lockfile).

This proposed change avoids creating lockfile from bosco.

As an alternative we could run it "--production" instead.

@tomruttle please chime in