### PR TITLE
Improvements to missing team errors

### DIFF
--- a/commands/clone.js
+++ b/commands/clone.js
@@ -161,7 +161,7 @@ function fetch(bosco, team, repos, repoRegex, args, next) {
 function cmd(bosco, args, next) {
   var repoPattern = bosco.options.repo;
   var repoRegex = new RegExp(repoPattern);
-  var team = bosco.getTeam();
+  var team = bosco.getTeam() || 'no-team';
   var teamConfig = bosco.config.get('teams:' + team);
 
   var client = github.client(bosco.config.get('github:authToken'), {hostname: bosco.config.get('github:apiHostname') });

--- a/commands/run.js
+++ b/commands/run.js
@@ -183,13 +183,10 @@ function cmd(bosco, args, allDone) {
       var unknownServices = _.filter(runList, function(i) { return !_.includes(['docker', 'docker-compose', 'node', 'skip'], i.service.type); });
       if (unknownServices.length > 0) {
         bosco.error('Unable to run services of un-recognised type: ' + _.map(unknownServices, 'name').join(', ').cyan + '. Check their bosco-service.json configuration.');
-        bosco.error('This may be due to either out of date cached content, or missing github configuration for your organisation, try the following:');
-        /* eslint-disable no-console */
-        console.log('');
-        console.log('bosco config set github:org <organisation>');
-        console.log('bosco run --nocache');
-        console.log('');
-        /* eslint-enable no-console */
+        bosco.warn('This may be due to either:');
+        bosco.warn('- Team not being configured: ' + 'bosco team setup'.yellow);
+        bosco.warn('- Out of date cached content: ' + 'bosco run --nocache'.yellow);
+        bosco.warn('- Missing github configuration: ' + 'bosco config set github:org <organisation>'.yellow);
       }
       async.mapSeries([
           {services: dockerServices, type: 'docker', limit: bosco.concurrency.cpu},

--- a/commands/team.js
+++ b/commands/team.js
@@ -132,7 +132,13 @@ function cmd(bosco, args, next) {
   if (action === 'ls') { return showTeams(bosco); }
   if (action === 'ln') { return linkTeam(bosco, args.shift(), args.shift(), next); }
   if (action === 'setup') { return setupInitialLink(bosco, next); }
-  bosco.log('You are in team: ' + (bosco.getTeam() ? bosco.getTeam().cyan : 'Not in a workspace!'.red));
+
+  var teamName = bosco.getTeam();
+  if (!teamName) {
+    bosco.log('Not in a team!'.red);
+  } else {
+    bosco.log('You are in team: ' + teamName.cyan);
+  }
 }
 
 module.exports.cmd = cmd;

--- a/index.js
+++ b/index.js
@@ -112,8 +112,12 @@ Bosco.prototype.run = function(options) {
 
     self.checkInService();
 
-    var teamDesc = self.getTeam() || 'Outside workspace!';
-    self.log('Initialised using [' + self.options.configFile.magenta + '] in environment [' + self.options.environment.green + '] with team [' + teamDesc.cyan + ']');
+    var teamDesc = self.getTeam();
+    self.log(
+      'Initialised using [' + self.options.configFile.magenta + '] ' +
+      'in environment [' + self.options.environment.green + '] ' +
+      (teamDesc ? 'with team [' + teamDesc.cyan + ']' : 'without a team!'.red)
+    );
     self._cmd();
   });
 };
@@ -375,19 +379,19 @@ Bosco.prototype.getWorkspacePath = function() {
 Bosco.prototype.getTeam = function() {
   var self = this;
   var teamConfig = self.config.get('teams');
-  var currentTeam;
+  var currentTeam = null;
   _.keys(teamConfig).forEach(function(team) {
     if (self.options.workspace.indexOf(teamConfig[team].path) >= 0) {
       currentTeam = team;
     }
   });
-  return currentTeam || 'no-team';
+  return currentTeam;
 };
 
 Bosco.prototype.getRepos = function() {
   var self = this;
   var team = self.getTeam();
-  if (team === 'no-team') {
+  if (!team) {
     return [path.relative('..', '.')];
   }
   return self.config.get('teams:' + team).repos;

--- a/src/RunListHelper.js
+++ b/src/RunListHelper.js
@@ -3,16 +3,17 @@ var _ = require('lodash');
 var github = require('octonode');
 var async = require('async');
 var treeify = require('treeify');
-var teamWarning = false;
+var warnOrganisationMissing = true;
 
 function getGithubRepo(bosco, repo) {
   var team = bosco.getTeam();
-  var organisation = team === 'no-team' ? bosco.config.get('github:org') : team.split('/')[0];
+  var organisation = !team ? bosco.config.get('github:org') : team.split('/')[0];
   var githubRepo;
   if (!organisation) {
-    if (!teamWarning) {
-      bosco.warn('Ensure you are in a team, or have a github:org set, e.g. ' + 'bosco config set github:org tes'.yellow);
-      teamWarning = true;
+    if (warnOrganisationMissing) {
+      bosco.warn('Ensure you configured your github organisation: ' + 'bosco config set github:org <organisation>'.yellow);
+      bosco.warn('Ensure you configured your team: ' + 'bosco team setup'.yellow);
+      warnOrganisationMissing = false;
     }
   } else {
     githubRepo = organisation + '/' + repo;


### PR DESCRIPTION
The existing code made wrong assumptions on the return type of the getTeam method, fixed that and improved error messaging.

When running `bosco team`:

<img width="816" alt="screen shot 2017-03-02 at 10 55 32" src="https://cloud.githubusercontent.com/assets/1333608/23504487/967e1002-ff37-11e6-987b-4c3ceedb7c4c.png">

<img width="849" alt="screen shot 2017-03-02 at 11 02 16" src="https://cloud.githubusercontent.com/assets/1333608/23504512/b97a516a-ff37-11e6-9be2-d2bb25eaa0d2.png">

when running `bosco run -d`

<img width="865" alt="screen shot 2017-03-02 at 10 56 26" src="https://cloud.githubusercontent.com/assets/1333608/23504530/cfdf818c-ff37-11e6-88ca-b132326c4fd7.png">

<img width="864" alt="screen shot 2017-03-02 at 10 56 39" src="https://cloud.githubusercontent.com/assets/1333608/23504535/d5ec0f64-ff37-11e6-88a4-d884a67df911.png">
