### PR TITLE
Ensure latest version

### DIFF
--- a/config/options.json
+++ b/config/options.json
@@ -62,15 +62,13 @@
     "type": "number",
     "default": 0,
     "desc": "Delay on browser refresh - useful to increase if refresh requires server restarts"
-  },
-  {
+  }, {
     "name": "verbose",
     "alias": "v",
     "type": "boolean",
     "default": false,
     "desc": "Verbose output"
-  },
-  {
+  }, {
     "name": "nocache",
     "type": "boolean",
     "desc": "Do not use the remote config cache"

--- a/index.js
+++ b/index.js
@@ -311,6 +311,10 @@ Bosco.prototype._checkVersion = function() {
       var version = jsonBody['dist-tags'].latest;
       if (semver.lt(self.options.version, version)) {
         self.error('There is a newer version (Local: ' + self.options.version.yellow + ' < Remote: ' + version.green + ') of Bosco available, you should upgrade!');
+        if (self.config.get('ensureLatestVersion')) {
+          self.error("Bosco is not up to date - exiting. Please upgrade Bosco or disable the 'ensureLatestVersion' option to continue.");
+          process.exit(1);
+        }
         self.console.log('\r');
       }
     }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ Bosco.prototype.init = function(options) {
   self.options = _.defaults(_.clone(options), self._defaults);
 
   // Load base bosco config from home folder unless over ridden with path
-  self.options.configPathSet = options.configPath ? true : false;
   self.options.configPath = options.configPath ? path.resolve(options.configPath) : self.findConfigFolder();
   self.options.configFile = options.configFile ? path.resolve(options.configFile) : [self.options.configPath, 'bosco.json'].join('/');
   self.options.defaultsConfigFile = [self.options.configPath, 'defaults.json'].join('/');


### PR DESCRIPTION
I was recently caught out because my local `nginx` was misbehaving and I didn't notice that `bosco` was out of date (on the node version used for the project I was running). Noticing would have saved me a heap of time, so from now on I want Bosco to be stricter with me.

`bosco` already checks to see whether you are running the latest version. This PR introduces a 'strict mode', which will kill the current process if you're not.

```js
// bosco config
{
  // ...
  "strict": true
}
```

Note that the version check is asynchronous, so there will be times when `bosco` doesn't find out in time that it's out of date.

Feel free to suggest better names for the setting 🐶

/cc @cliftonc @andy-duncan 
