### PR TITLE
Allow all service configuration to exist in package.json if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,70 @@ If any repository already exists locally it will skip it.  Typically you only us
 
 ## Service Configuration
 
+You can use either a specific configuration file - `bosco-service.json` - or add bosco specific configuration to your `package.json` file, depending on how you prefer to manage per service config.  Anything in the `package.json` will take precedence.
+
+### package.json
+
+You can add the following sections (in addition to others that are typically there):
+
+ - `scripts`: bosco expects there to be a `build` and `build:watch` command if you want bosco to run a build and or watch a build for you.
+ - `service`: this is where you can add configuration related to the service dependencies, or any docker configuration if this service typically starts as a docker container.
+ - `cdn`: this is where you add the bosco cdn configuration to allow it to manage the serve / push of static assets.
+ - `tags`: you can add tags that allow you to control groups of services to run / stop.
+
+```
+{
+  "main": "server.js",
+  "scripts": {
+    "build": "echo 'This is the pseudo output of a build command.'",
+    "build:watch": "echo \"COMPLETA\"; sleep 1"
+  },
+  "tags": [ "testy" , "besty" ],
+  "service": {
+    "dependsOn": [
+      "project1"
+    ]
+  },
+  "cdn": {
+    "ready": "COMPLETA",
+    "timeout": 5000,
+    "libraries": [
+        {
+          "basePath": "src/client/vendor",
+          "glob": "**/**"
+        }
+    ],
+    "assets": {
+      "basePath": "/dist",
+      "alreadyMinified": true,
+      "sourceMapExtension": ".map",
+      "js": {
+        "compiled": [
+          "js/compiled.js",
+          "js/compiled.js.map"
+        ]
+      },
+      "css": {
+        "compiled": [
+          "css/compiled.css"
+        ]
+      }
+    },
+    "files": {
+      "files-top": {
+        "basePath": "/dist",
+        "swf": [
+          "swf/flash.swf"
+        ]
+      }
+    }
+  }
+}
+```
+
 ### bosco-service.json
 
-If services want to take part in the static asset pipeline that Bosco provides, as well as allow bosco to start and stop them, then they need a bosco-service.json config file.
+Alternatively to adding service information to package.json, if services want to take part in the static asset pipeline that Bosco provides, as well as allow bosco to start and stop them, then they need a bosco-service.json config file.
 
 e.g.
 

--- a/index.js
+++ b/index.js
@@ -517,8 +517,9 @@ Bosco.prototype.getRepoName = function() {
 
 Bosco.prototype.checkInService = function() {
   var self = this;
-  var cwd = path.resolve('bosco-service.json');
-  if (self.exists(cwd) && self.options.service) {
+  var bs = path.resolve('bosco-service.json');
+  var pkg = path.resolve('package.json');
+  if ((self.exists(bs) || self.exists(pkg)) && self.options.service) {
     self.options.inService = true;
     self.options.inServiceRepo = self.getRepoName();
     // Replace getRepos

--- a/src/ExternalBuild.js
+++ b/src/ExternalBuild.js
@@ -79,7 +79,9 @@ module.exports = function(bosco) {
         next(err);
       }
 
-      if (options.watchCallback) { options.watchCallback(err, service, output); }
+      if (options.watchCallback) {
+        options.watchCallback(err, service, output);
+      }
     }
 
     if (!watchingService) {

--- a/src/ExternalBuilders/SpawnWatch.js
+++ b/src/ExternalBuilders/SpawnWatch.js
@@ -84,5 +84,6 @@ module.exports = function(bosco) {
     wc.stdout.on('data', function(data) { onChildOutput('stdout', data); });
     wc.stderr.on('data', function(data) { onChildOutput('stderr', data); });
     wc.on('exit', onChildExit);
+    wc.on('error', onChildExit);
   };
 };

--- a/src/StaticUtils.js
+++ b/src/StaticUtils.js
@@ -34,6 +34,9 @@ module.exports = function(bosco) {
       var packageJson = JSON.parse(fs.readFileSync(repoPackageFile) || {});
       if (packageJson.service) {
         boscoRepo.service = packageJson.service;
+        if (bosco.exists(boscoRepoConfig)) {
+          bosco.warn('You configuration for: ' + repo.cyan + ' in both bosco-service.json and package.json, suggest you pick one to avoid any unexpected behaviour!');
+        }
       }
       if (packageJson.cdn) {
         if (packageJson.cdn.libraries) {

--- a/src/StaticUtils.js
+++ b/src/StaticUtils.js
@@ -33,7 +33,7 @@ module.exports = function(bosco) {
     if (bosco.exists(repoPackageFile)) {
       var packageJson = JSON.parse(fs.readFileSync(repoPackageFile) || {});
       if (packageJson.service) {
-        boscoRepo.service = _.merge(boscoRepo.service, packageJson.service);
+        boscoRepo.service = packageJson.service;
       }
       if (packageJson.cdn) {
         if (packageJson.cdn.libraries) {

--- a/test/ExternalBuild.test.js
+++ b/test/ExternalBuild.test.js
@@ -180,7 +180,7 @@ describe('ExternalBuild', function() {
       name: 'service',
       repoPath: localBosco.getRepoPath(''),
       build: {
-        command: 'echo hello; sleep 5',
+        command: 'echo hello; sleep 1',
         watch: {
           timeout: 100
         }
@@ -190,11 +190,15 @@ describe('ExternalBuild', function() {
       watchBuilds: true,
       watchRegex: /./,
       watchCallback: function(err, service, output) {
-        expect(output.state).to.be('timeout');
-        expect(localBosco.process.stderr._data).to.be.an('array');
-        expect(localBosco.process.stderr._data.length).to.be.greaterThan(0);
-        expect(localBosco.process.stderr._data[0]).to.contain('timed out');
-        done();
+        // Will call watch callback twice - first for timeout, second for child-exit
+        if (output.state === 'timeout') {
+          expect(localBosco.process.stderr._data).to.be.an('array');
+          expect(localBosco.process.stderr._data.length).to.be.greaterThan(0);
+          expect(localBosco.process.stderr._data[0]).to.contain('timed out');
+        } else {
+          expect(output.state).to.be('child-exit');
+          done();
+        }
       }
     };
 

--- a/test/s3push.test.js
+++ b/test/s3push.test.js
@@ -10,7 +10,7 @@ var s3push = require('../commands/s3push');
 var StaticUtils = require('../src/StaticUtils');
 
 describe('s3push', function() {
-  this.timeout(2000);
+  this.timeout(5000);
   this.slow(500);
 
   it('should fail if the build fails', function(done) {


### PR DESCRIPTION
No requirement for bosco-service.json.

This makes things a little more aligned with modern conventions to avoid the proliferation of json files in project root folders, but retains the old behaviour.

I will make a command that copies the config from a service over from bosco-service.json into package.json and deletes (so we can transition if desired with minimal fuss).

This is linked to testing some ideas with @MerlinDMC about making our build and deploy process more convention based on data in the services, using bosco on the build server to replace many legacy Makefile tasks etc. 