### PR TITLE
Cater for the case where stdout feeds more than one line

### DIFF
--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -60,6 +60,7 @@ Runner.prototype.getInterpreter = function(bosco, options, next) {
     e.stdout.on('data', function(data) {
       if (data.indexOf('Found') === 0) {
         found = true;
+        interpreter = data.replace(/.*\n/, '').replace('\n', '');
       } else {
         if (found) {
           interpreter = data.replace('\n', '');


### PR DESCRIPTION
This has only been tested on my machine where it does this multiline thing - it needs testing on other machines that don't, but I've Thought Deeply about what happens then, and can't see a problem.