### PR TITLE
Don't call nvm.sh if nvm is already in PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ Bosco.prototype.init = function(options) {
   self.options.defaultsConfigFile = [self.options.configPath, 'defaults.json'].join('/');
 
   // NVM presets
-  self.options.nvmSh = '. ${NVM_DIR:-$HOME/.nvm}/nvm.sh && ';
+  self.options.nvmSh = 'command -v nvm >/dev/null 2>&1 || { . ${NVM_DIR:-$HOME/.nvm}/nvm.sh; } && ';
   self.options.nvmUse = self.options.nvmSh + 'nvm use;';
   self.options.nvmUseDefault = self.options.nvmSh + 'nvm use default;';
   self.options.nvmWhich = self.options.nvmSh + 'nvm which';


### PR DESCRIPTION
Adds a POSIX compliant way of checking if nvm is already in scope and skip calling nvm.sh.

It's useful if you installed nvm in a saner way than the script and don't need to run nvm.sh all the time (or if you don't have nvm.sh)