### PR TITLE
Remove NVM version dependency check

### DIFF
--- a/index.js
+++ b/index.js
@@ -571,15 +571,12 @@ Bosco.prototype.hasNvm = function() {
   var nvmDir = process.env.NVM_DIR || '';
   var homeNvmDir = process.env.HOME ? path.join(process.env.HOME, '.nvm') : '';
 
-  var nvmVersion = '0.0.0';
-  if (nvmDir && this.exists(path.join(nvmDir, 'nvm.sh'))) {
-    nvmVersion = require(path.join(nvmDir, 'package.json')).version;
-  } else if (homeNvmDir && this.exists(path.join(homeNvmDir, 'nvm.sh'))) {
-    nvmVersion = require(path.join(homeNvmDir, 'package.json')).version;
-  } else {
+  var hasNvm = (nvmDir && this.exists(path.join(nvmDir, 'nvm.sh'))) ||
+    (homeNvmDir && this.exists(path.join(homeNvmDir, 'nvm.sh')));
+
+  if (!hasNvm) {
     this.error('Could not find nvm');
-    return false;
   }
 
-  return semver.satisfies(nvmVersion, '>=0.21.0');  // First version with nvm which
+  return hasNvm;
 };


### PR DESCRIPTION
If NVM is installed from git or homebrew then the package.json for NVM
may not exist, resulting in bosco failing to work.  The version check
was to ensure at least nvm 0.21.0 was installed for some required API changes.
0.21.0 was released over 3 years ago so it's safe to assume new users
will definitely have a newer version and those who don't will be able to
figure it out.