### PR TITLE
Add --system-node flag to skip NVM use

### DIFF
--- a/config/options.json
+++ b/config/options.json
@@ -43,6 +43,10 @@
     "type": "boolean",
     "desc": "Force over ride on publish even if no changes"
   }, {
+    "name": "system-node",
+    "type": "boolean",
+    "desc": "Skip NVM and use system supplied node binary"
+  }, {
     "name": "install-missing",
     "alias": "i",
     "type": "boolean",

--- a/index.js
+++ b/index.js
@@ -39,11 +39,19 @@ Bosco.prototype.init = function (options) {
   self.options.defaultsConfigFile = [self.options.configPath, 'defaults.json'].join('/');
 
   // NVM presets
-  self.options.nvmSh = '. ${NVM_DIR:-$HOME/.nvm}/nvm.sh && ';
-  self.options.nvmUse = self.options.nvmSh + 'nvm use;';
-  self.options.nvmUseDefault = self.options.nvmSh + 'nvm use default;';
-  self.options.nvmWhich = self.options.nvmSh + 'nvm which';
-  self.options.nvmInstall = self.options.nvmSh + 'nvm install';
+  if (self.options['system-node']) {
+    self.options.nvmSh = '';
+    self.options.nvmUse = '';
+    self.options.nvmUseDefault = '';
+    self.options.nvmWhich = '';
+    self.options.nvmInstall = '';
+  } else {
+    self.options.nvmSh = '. ${NVM_DIR:-$HOME/.nvm}/nvm.sh && ';
+    self.options.nvmUse = self.options.nvmSh + 'nvm use;';
+    self.options.nvmUseDefault = self.options.nvmSh + 'nvm use default;';
+    self.options.nvmWhich = self.options.nvmSh + 'nvm which';
+    self.options.nvmInstall = self.options.nvmSh + 'nvm install';
+  }
 
   self.options.cpus = require('os').cpus().length;
   self.options.ip = ip.address();
@@ -566,6 +574,10 @@ Bosco.prototype.exists = function (checkPath) {
 };
 
 Bosco.prototype.hasNvm = function () {
+  if (this.options['system-node']) {
+    return true;
+  }
+
   var nvmDir = process.env.NVM_DIR || '';
   var homeNvmDir = process.env.HOME ? path.join(process.env.HOME, '.nvm') : '';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bosco",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Bosco will take care of your microservices, just don't try and use him on a plane.",
   "main": "index.js",
   "scripts": {

--- a/src/RunWrappers/Node.js
+++ b/src/RunWrappers/Node.js
@@ -53,7 +53,7 @@ Runner.prototype.getInterpreter = function (bosco, options, next) {
   var installing;
   var found = false;
   var hasNvmRc = bosco.exists(path.join(options.cwd, '.nvmrc'));
-  if (hasNvmRc) {
+  if (hasNvmRc && !bosco.options['system-node']) {
     var e = childProcess.exec(bosco.options.nvmWhich, { cwd: options.cwd });
     e.stdout.setEncoding('utf8');
     e.stderr.setEncoding('utf8');


### PR DESCRIPTION
- This will allow for NVM to be unavailable and execute commands against the
  system wide node version