### PR TITLE
Improve timeout detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bosco",
-  "version": "2.0.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bosco",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Bosco will take care of your microservices, just don't try and use him on a plane.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Lately I've been getting a few timeouts while running bosco deps.
Bosco will consider a service up when it can connect to the service port and the connection will stay open for more than 200ms.

Two things are failing that check:
1- `infra-rabbitmq` is disconnecting straight away clients that are connecting too aggressively (so we never reach 200ms connection time)
2- some services are sending data when we connect to the port. So when we call `socket.end()` after 200ms it will just [half-close the socket](https://nodejs.org/api/net.html#net_socket_end_data_encoding_callback) and it won't ever reach the  check that is happening `on('close')`

To fix those two problems, I've updated the retry connection time from 50ms to 200ms, and I've changed the logic to consider a service up if it's sending data

@andy-duncan @rouanw 
