### PR TITLE
Add 'org' flag (enable use outside of team folder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ You can use a number of parameters to control the behaviour of Bosco.  Parameter
 |-f, --force|Force over ride of any files|false|
 |-s, --service|Inside single service|false|
 |--nocache|Ignore local cache for github projects|false|
+|--org --organisation|Github org to search for repos in - overrides current folder or Bosco config. Means you can use Bosco outside of a team folder|false|
 
 To see all possible commands and parameters, just type 'bosco'.
 

--- a/commands/bundle-check.js
+++ b/commands/bundle-check.js
@@ -45,7 +45,7 @@ function cmd(bosco, args, next) {
       if (service === 'site-assets') {
         githubName = 'service-site-assets';
       } // Name hack
-      helper.getServiceConfigFromGithub(bosco, githubName, {}, function (err, config) {
+      helper.getServiceConfigFromGithub(bosco, githubName, {}, null, function (err, config) {
         if (err || !config) { return cb(); }
 
         // Pull the discrete bundles from the config

--- a/commands/cdn.js
+++ b/commands/cdn.js
@@ -59,7 +59,7 @@ function cmd(bosco, args) {
   if (!repos) return bosco.error('You are repo-less :( You need to initialise bosco first, try \'bosco clone\'.');
 
   function getRunList(next) {
-    RunListHelper.getRunList(bosco, repos, repoRegex, watchRegex, repoTag, false, next);
+    RunListHelper.getRunList(bosco, repos, repoRegex, watchRegex, repoTag, false, null, next);
   }
 
   function startServer(staticAssets, staticRepos, serverPort) {

--- a/commands/pull-docker.js
+++ b/commands/pull-docker.js
@@ -88,7 +88,7 @@ function cmd(bosco, args, next) {
       return cb();
     }
     bosco.log('Checking for remote docker images to pull ...');
-    RunListHelper.getRunList(bosco, repos, repoRegex, watchNothing, null, false, function (err, services) {
+    RunListHelper.getRunList(bosco, repos, repoRegex, watchNothing, null, false, null, function (err, services) {
       if (err) {
         return next(err);
       }

--- a/commands/run.js
+++ b/commands/run.js
@@ -65,6 +65,11 @@ module.exports = {
       name: 'exclude',
       type: 'string',
       desc: 'Exclude any repositories that match this regex'
+    },
+    {
+      name: 'organisation',
+      alias: 'org',
+      desc: 'Specify Github org to search for repos in - overrides folder or Bosco config'
     }
   ]
 };
@@ -76,6 +81,7 @@ function cmd(bosco, args, allDone) {
   var watchPattern = bosco.options.watch || '$a';
   var watchRegex = new RegExp(watchPattern);
   var repoTag = bosco.options.tag;
+  var organisation = bosco.options.organisation;
 
   var repos;
   if (bosco.options.list) {
@@ -100,7 +106,7 @@ function cmd(bosco, args, allDone) {
   }
 
   function getRunList(next) {
-    RunListHelper.getRunList(bosco, repos, repoRegex, watchRegex, repoTag, false, next);
+    RunListHelper.getRunList(bosco, repos, repoRegex, watchRegex, repoTag, false, organisation, next);
   }
 
   function startRunnableServices(next) {
@@ -248,7 +254,7 @@ function cmd(bosco, args, allDone) {
 
   if (bosco.options.show) {
     bosco.log('Dependency tree for current repo filter:');
-    return RunListHelper.getRunList(bosco, repos, repoRegex, watchRegex, repoTag, true, done);
+    return RunListHelper.getRunList(bosco, repos, repoRegex, watchRegex, repoTag, true, organisation, done);
   }
 
   bosco.log('Run each microservice, will inject ip into docker: ' + bosco.options.ip.cyan);

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -86,7 +86,7 @@ function cmd(bosco, args, done) {
   }
 
   function stopRunningServices(cb) {
-    RunListHelper.getRunList(bosco, repos, repoRegex, null, repoTag, false, function (err, services) {
+    RunListHelper.getRunList(bosco, repos, repoRegex, null, repoTag, false, null, function (err, services) {
       async.mapLimit(services, bosco.concurrency.network, function (boscoService, next) {
         var repo = boscoService.name;
         if (!repo.match(repoRegex)) return next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bosco",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2307,6 +2307,12 @@
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -4827,21 +4833,13 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://npm.tescloud.com/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://npm.tescloud.com/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "jsbn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bosco",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Bosco will take care of your microservices, just don't try and use him on a plane.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds an optional flag, `--org` or `--organisation`, that overrides the organisation set in local Bosco config or that associated with the current folder during `bosco team setup`.

This means you can run an app outside a team folder (lack of org was the only thing stopping you before). Bosco will simply run all the dependencies in docker containers. The org you set obviously needs to be the correct Github org for the microservices you're trying to run.

Example: `bosco run -d --org tes`

Also fixes a few moderate npm audit vulnerabilities.

@varvarra cc'ing you as you requested it. Also @rouanw @ksnll 