### PR TITLE
Make cached service information expire after 48h. Enable use of stale…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ You can use a number of parameters to control the behaviour of Bosco.  Parameter
 |-f, --force|Force over ride of any files|false|
 |-s, --service|Inside single service|false|
 |--nocache|Ignore local cache for github projects|false|
+|--offline|Ignore expired cache of remote service data and use local if available|false|
 
 To see all possible commands and parameters, just type 'bosco'.
 

--- a/config/options.json
+++ b/config/options.json
@@ -64,9 +64,15 @@
     "type": "boolean",
     "default": false,
     "desc": "No logging output"
-  }, {
+  },
+  {
     "name": "nocache",
     "type": "boolean",
     "desc": "Do not use the remote config cache"
+  },
+  {
+    "name": "offline",
+    "type": "boolean",
+    "desc": "Forgoes fetching config from github. Uses stale cache where applicable"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bosco",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "description": "Bosco will take care of your microservices, just don't try and use him on a plane.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
… via --offline flag

The cached service information from github does not expire locally. This would be fine assuming nothing changes - but it does.

Adding an expiry (48h was chosen ...because) will force bosco to refresh this information.
Scenarios that this will now solve:
- Changes to sub dependencies when running a service
- Changes to configuration of a service, for example docker image location. 

It was pointed out that such a scenario breaks extended offline working - so an `--offline` flag is added which counters the check for stale config.

This is an example to solve the issue, someone closer to the codebase or a more frequent user might find something better.